### PR TITLE
Add missing prop filterText for roles/groups modal filters

### DIFF
--- a/src/components/MultiSelect.component.js
+++ b/src/components/MultiSelect.component.js
@@ -14,6 +14,7 @@ const MultiSelect = React.createClass({
         isLoading: React.PropTypes.bool,
         sortable: React.PropTypes.bool,
         height: React.PropTypes.number,
+        filterText: React.PropTypes.string,
     },
 
     getDefaultProps() {
@@ -62,7 +63,7 @@ const MultiSelect = React.createClass({
     },
 
     render() {
-        const { errors, label, sortable, height } = this.props;
+        const { errors, label, sortable, height, filterText } = this.props;
 
         const styles = {
             labelStyle: {
@@ -99,6 +100,7 @@ const MultiSelect = React.createClass({
                     onRemoveItems={this._onItemRemoved}
                     onOrderChanged={sortable ? this._onOrderChanged : undefined}
                     height={height}
+                    filterText={filterText}
                 />
             </div>
         );


### PR DESCRIPTION
= PR. Pull request template

### :pushpin: References

* **Issue:** Closes #101

### :memo: Implementation

- Pass `filterText` from `MultiSelect` to `GroupEditor`.

### :art: Screenshots

![screenshot from 2018-09-27 10-08-47](https://user-images.githubusercontent.com/24643/46132101-81b95300-c23d-11e8-8c23-64ac0eca2315.png)

