### PR TITLE
Use query param for a more general text filter

### DIFF
--- a/src/List/List.component.js
+++ b/src/List/List.component.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import _ from 'lodash';
 import log from 'loglevel';
 import isIterable from 'd2-utilizr/lib/isIterable';
 import DataTable from '../data-table/DataTable.component';
@@ -40,7 +41,6 @@ import Settings from '../models/settings';
 import OrgUnitsFilter from '../components/OrgUnitsFilter.component';
 import FilterListIcon from 'material-ui/svg-icons/content/filter-list';
 import AnimateHeight from 'react-animate-height';
-import last from 'lodash/fp/last';
 
 const pageSize = 50;
 
@@ -304,29 +304,27 @@ const List = React.createClass({
     },
 
     filterList({page = 1} = {}) {
-        const order = this.state.sorting ?
-            (this.state.sorting[0] + ":i" + this.state.sorting[1]) : null;
+        const order = this.state.sorting
+            ? (this.state.sorting[0] + ":i" + this.state.sorting[1])
+            : null;
         const { filterByRoles, filterByGroups, filterByOrgUnits, filterByOrgUnitsOutput } = this.state;
         const { showAllUsers, pager, searchString } = this.state;
+        const inFilter = (field) => _(field).isEmpty() ? null : ["in", field];
+        const getIdFromPath = path => _.last(path.split("/"));
 
         const options = {
             modelType: this.props.params.modelType,
             canManage: !showAllUsers,
             order: order,
+            query: searchString,
             filters: {
-                "displayName":
-                    searchString ? ["ilike", searchString] : null,
-                "userCredentials.userRoles.id":
-                    _(filterByRoles).isEmpty() ? null : ["in", filterByRoles],
-                "userGroups.id":
-                    _(filterByGroups).isEmpty() ? null : ["in", filterByGroups],
-                "organisationUnits.id":
-                    _(filterByOrgUnits).isEmpty() ? null : ["in", filterByOrgUnits.map(path => last(path.split("/")))],
-                "dataViewOrganisationUnits.id":
-                    _(filterByOrgUnitsOutput).isEmpty() ? null : ["in", filterByOrgUnitsOutput.map(path => last(path.split("/")))],
+                "userCredentials.userRoles.id": inFilter(filterByRoles),
+                "userGroups.id": inFilter(filterByGroups),
+                "organisationUnits.id": inFilter(filterByOrgUnits.map(getIdFromPath)),
+                "dataViewOrganisationUnits.id": inFilter(filterByOrgUnitsOutput.map(getIdFromPath)),
             },
         };
-
+        
         const paginatedOptions = {
             ...options,
             paging: true,


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #103 

### :memo: Implementation

- Currently we were using `displayName:ilike:STRING`. Now we use the specific `query` param for `/users`, which performs an insensitive search over fields _username,_ _firstName_, _surname_ and _email_: 

https://docs.dhis2.org/2.29/en/developer/html/dhis2_developer_manual_full.html#webapi_users_query

### :art: Screenshots

![screenshot from 2018-09-28 10-00-01](https://user-images.githubusercontent.com/24643/46195790-8cd7b600-c305-11e8-82e6-0dc711b51a87.png)
