### PR TITLE
Fix edit action for >= 2.30

### DIFF
--- a/src/List/context.actions.js
+++ b/src/List/context.actions.js
@@ -39,7 +39,7 @@ async function goToUserEditPage(user) {
     const d2 = await getD2();
     const baseUrl = d2.system.systemInfo.contextPath;
     const { major, minor } = d2.system.version;
-    // DHIS" >= 2.30 uses a new React user-app
+    // DHIS2 >= 2.30 uses a new React user-app
     const url = lexicographicalCompare([major, minor], [2, 30]) >= 0
         ? `${baseUrl}/dhis-web-user/index.html#/users/edit/${user.id}`
         : `${baseUrl}/dhis-web-maintenance-user/alluser.action?key=${user.username}`;

--- a/src/List/context.actions.js
+++ b/src/List/context.actions.js
@@ -29,10 +29,21 @@ async function assignToOrgUnits(selectedUsers, field, titleKey) {
     });
 }
 
+// Compare two arrays lexicographically and return -1 (if xs < ys), 0 (if xs == ys) or 1 (if xs > ys).
+function lexicographicalCompare(xs, ys) {
+    const compare = (x, y) => x < y ? -1 : (x === y ? 0 : 1);
+    return _(xs).zipWith(ys, compare).find() || 0;
+}
+
 async function goToUserEditPage(user) {
     const d2 = await getD2();
     const baseUrl = d2.system.systemInfo.contextPath;
-    const url = `${baseUrl}/dhis-web-maintenance-user/alluser.action?key=${user.username}`;
+    const { major, minor } = d2.system.version;
+    // DHIS" >= 2.30 uses a new React user-app
+    const url = lexicographicalCompare([major, minor], [2, 30]) >= 0
+        ? `${baseUrl}/dhis-web-user/index.html#/users/edit/${user.id}`
+        : `${baseUrl}/dhis-web-maintenance-user/alluser.action?key=${user.username}`;
+
     window.open(url, '_blank');
 }
 


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #100 

### :memo: Implementation

- Get current Dhis2 version from: `d2.system.version`.
- <= 2.29 uses the old app with list filter /dhis-web-maintenance-user/alluser.action?key=USERNAME, >= 2.30 uses /dhis-web-user/index.html#/users/edit/ID

