### PR TITLE
Feature/delete context action

### DIFF
--- a/src/List/List.component.js
+++ b/src/List/List.component.js
@@ -8,6 +8,7 @@ import DetailsBox from './DetailsBox.component';
 import contextActions from './context.actions';
 import detailsStore from './details.store';
 import listStore from './list.store';
+import deleteUserStore from './deleteUser.store';
 import listActions from './list.actions';
 import ObserverRegistry from '../utils/ObserverRegistry.mixin';
 import Paper from 'material-ui/Paper/Paper';
@@ -268,6 +269,8 @@ const List = React.createClass({
             this.setAssignState("replicateUser", replicateUser);
         });
 
+        const deleteUserStoreDisposable = deleteUserStore.subscribe(users => this.filterList());
+
         this.registerDisposable(detailsStoreDisposable);
         this.registerDisposable(orgUnitAssignmentStoreDisposable);
         this.registerDisposable(rolesStoreDisposable);
@@ -276,6 +279,7 @@ const List = React.createClass({
         this.registerDisposable(userRolesAssignmentDialogStoreDisposable);
         this.registerDisposable(userGroupsAssignmentDialogStoreDisposable);
         this.registerDisposable(replicateUserDialogStoreDisposable);
+        this.registerDisposable(deleteUserStoreDisposable);
 
         this.filterList();
     },

--- a/src/List/context.actions.js
+++ b/src/List/context.actions.js
@@ -4,6 +4,7 @@ import orgUnitAssignmentDialogStore from './organisation-unit-dialog/organisatio
 import userRolesAssignmentDialogStore from './userRoles.store';
 import userGroupsAssignmentDialogStore from './userGroups.store';
 import replicateUserStore from './replicateUser.store';
+import deleteUserStore from './deleteUser.store';
 import _m from '../utils/lodash-mixins';
 import { getOrgUnitsRoots } from '../utils/orgUnits';
 
@@ -93,6 +94,13 @@ const contextActions = [
         multiple: false,
         onClick: user => goToUserEditPage(user),
         allowed: checkAccess(["update"]),
+    },
+    {
+        name: 'remove',
+        icon: 'delete',
+        multiple: true,
+        allowed: checkAccess(["delete"]),
+        onClick: datasets => deleteUserStore.delete(datasets),
     },
     {
         name: 'replicateUser',

--- a/src/List/deleteUser.store.js
+++ b/src/List/deleteUser.store.js
@@ -1,0 +1,33 @@
+import Store from 'd2-ui/lib/store/Store';
+import { getInstance as getD2 } from 'd2/lib/d2';
+
+import snackActions from '../Snackbar/snack.actions';
+import _m from '../utils/lodash-mixins';
+
+export default Store.create({
+  async delete(users) {
+    const d2 = await getD2();
+    const t = d2.i18n.getTranslation.bind(d2.i18n);
+    const api = d2.Api.getApi();
+    const usersText = _m.joinString(t, users.map(user => user.username), 3, ", ");
+    const performDelete = () => {
+        const payload = { users: users.map(user => ({ id: user.id })) };
+
+        return api.post(`metadata?importStrategy=DELETE`, payload)
+            .then(response => {
+                snackActions.show({ message: t("users_deleted", { users: usersText }) });
+                this.setState(response);
+            })
+            .catch(response => {
+                snackActions.show({ message: response.message || 'Error' });
+            });
+    };
+
+    snackActions.show({
+        message: t("confirm_delete_users", { users: usersText }),
+        action: 'confirm',
+        autoHideDuration: 0,
+        onActionTouchTap: performDelete,
+    });
+  }
+});

--- a/src/Snackbar/SnackbarContainer.component.js
+++ b/src/Snackbar/SnackbarContainer.component.js
@@ -44,16 +44,19 @@ const SnackBarContainer = React.createClass({
             return null;
         }
 
+        const { message, action, autoHideDuration, onActionTouchTap } = this.state.snack;
+
         return (
             <Snackbar
-                style={{ maxWidth: 'auto', zIndex: 1000000 }}
-                bodyStyle={{ maxWidth: 'auto' }}
+                style={{ whiteSpace: 'nowrap', zIndex: 1000000 }}
+                bodyStyle={{ maxWidth: '100%' }}
+                contentStyle={{ display: 'flex' }}
                 ref="snackbar"
-                message={this.state.snack.message}
-                action={this.state.snack.action}
-                autoHideDuration={0}
+                message={message}
+                action={action}
+                autoHideDuration={autoHideDuration === undefined ? 6000 : autoHideDuration}
                 open={this.state.show}
-                onActionTouchTap={this.state.snack.onActionTouchTap}
+                onActionTouchTap={onActionTouchTap}
                 onRequestClose={this._closeSnackbar}
             />
         );

--- a/src/i18n/i18n_module_ar.properties
+++ b/src/i18n/i18n_module_ar.properties
@@ -99,3 +99,6 @@ table_exported=Table exported
 layout_settings=Layout settings
 extended_filters=Advanced filters
 table_layout_at_least_one_column=Select at least one column
+confirm=Confirm
+confirm_delete_users=Are you sure you want to remove the selected users? ($$users$$)
+users_deleted=Users removed successfully: $$users$$

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -99,3 +99,6 @@ table_exported=Table exported
 layout_settings=Layout settings
 extended_filters=Advanced filters
 table_layout_at_least_one_column=Select at least one column
+confirm=Confirm
+confirm_delete_users=Are you sure you want to remove the selected users? ($$users$$)
+users_deleted=Users removed successfully: $$users$$

--- a/src/i18n/i18n_module_es.properties
+++ b/src/i18n/i18n_module_es.properties
@@ -99,3 +99,6 @@ table_exported=Tabla exportada
 layout_settings=Opciones de columnas
 extended_filters=Filtros avanzados
 table_layout_at_least_one_column=Seleccione al menos una columna
+confirm=Confirmar
+confirm_delete_users=¿Está seguro de que quiere eliminar los usuarios seleccionados? ($$users$$)
+users_deleted=Usuarios eliminados con éxito: $$users$$

--- a/src/i18n/i18n_module_fr.properties
+++ b/src/i18n/i18n_module_fr.properties
@@ -99,3 +99,6 @@ table_exported=Table exported
 layout_settings=Opciones de columnas
 extended_filters=Advanced filters
 table_layout_at_least_one_column=Select at least one column
+confirm=Confirm
+confirm_delete_users=Are you sure you want to remove the selected users? ($$users$$)
+users_deleted=Users removed successfully: $$users$$


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #107

### :memo: Implementation

- Action works in single/multiple selection.
- Using label `Remove` (not `Delete`) to mimic official user-app. 
- Check access `object.access.deleted` to show or not the context actual.
- The feedback SnackBar automatically closes after 6000ms (like user-app does)

### :art: Screenshots

![screenshot from 2018-09-28 13-33-28](https://user-images.githubusercontent.com/24643/46206456-52c9dc80-c324-11e8-9522-015e09d12dd8.png)

![screenshot from 2018-09-28 13-33-39](https://user-images.githubusercontent.com/24643/46206458-53fb0980-c324-11e8-9a3d-3f527d173163.png)

![screenshot from 2018-09-28 13-33-48](https://user-images.githubusercontent.com/24643/46206459-552c3680-c324-11e8-86d3-626d9d4543d9.png)
