### PR TITLE
Show horizontal scroll bar on import table wrapper

### DIFF
--- a/src/components/ImportTable.component.js
+++ b/src/components/ImportTable.component.js
@@ -37,9 +37,11 @@ const styles = {
     dialogBody: {
         paddingTop: '10px',
     },
+    tableWrapper: {
+        overflow: "visible",
+    },
     table: {
         marginBottom: 5,
-        overflowX: "auto",
     },
     tableBody: {
         overflow: "visible",
@@ -504,7 +506,12 @@ class ImportTable extends React.Component {
 
         return (
             <div>
-                <Table fixedHeader={true} style={styles.table} bodyStyle={styles.tableBody}>
+                <Table
+                    fixedHeader={true}
+                    wrapperStyle={styles.tableWrapper}
+                    style={styles.table}
+                    bodyStyle={styles.tableBody}
+                >
                     <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
                         <TableRow>
                             <TableHeaderColumn style={styles.tableColumn}>#</TableHeaderColumn>


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #119 

### :memo: Implementation

- Set `overflow: visible` for table wrapper

### :art: Screenshots

![screenshot from 2018-11-14 13-08-06](https://user-images.githubusercontent.com/24643/48481729-dffebd00-e80e-11e8-9de6-fd0e8c8a2064.png)