### PR TITLE
Feature/allow plain user fields on import

### DIFF
--- a/src/components/ImportTable.component.js
+++ b/src/components/ImportTable.component.js
@@ -497,10 +497,12 @@ class ImportTable extends React.Component {
     }
 
     renderTable() {
+        const { d2 } = this.context;
         const { users } = this.state;
         const { maxUsers } = this.props;
         const canAddNewUser = users.size < maxUsers;
         const headers = this.getColumns().map(camelCaseToUnderscores);
+        const getColumnName = header => _(d2.i18n.translations).has(header) ? this.t(header) : header;
 
         return (
             <div>
@@ -510,7 +512,7 @@ class ImportTable extends React.Component {
                             <TableHeaderColumn style={styles.tableColumn}>#</TableHeaderColumn>
                             {headers.map(header =>
                                 <TableHeaderColumn key={header} style={styles.header}>
-                                    {this.t(header)}
+                                    {getColumnName(header)}
                                 </TableHeaderColumn>
                             )}
                             <TableHeaderColumn style={styles.actionsHeader}></TableHeaderColumn>

--- a/src/i18n/i18n_module_ar.properties
+++ b/src/i18n/i18n_module_ar.properties
@@ -9,6 +9,7 @@ cancel=CANCEL
 close=Close
 remove=Remove
 email=Email
+phone_number=Phone number
 apply=APPLY
 create=Create
 created=Created

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -9,6 +9,7 @@ cancel=CANCEL
 close=Close
 remove=Remove
 email=Email
+phone_number=Phone number
 apply=APPLY
 create=Create
 created=Created

--- a/src/i18n/i18n_module_es.properties
+++ b/src/i18n/i18n_module_es.properties
@@ -9,6 +9,7 @@ cancel=CANCELAR
 close=Cerrar
 remove=Eliminar
 email=Email
+phone_number=Teléfono
 apply=APLICAR
 create=Crear
 created=Creadas

--- a/src/i18n/i18n_module_fr.properties
+++ b/src/i18n/i18n_module_fr.properties
@@ -9,6 +9,7 @@ cancel=CANCEL
 close=Close
 remove=Remove
 email=Email
+phone_number=Phone number
 apply=APPLY
 create=Create
 created=Created

--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -50,6 +50,7 @@ const columnNameFromPropertyMapping = {
     firstName: "First name",
     surname: "Surname",
     email: "Email",
+    phoneNumber: "Phone number",
     lastUpdated: "Updated",
     lastLogin: "Last login",
     created: "Created",
@@ -170,12 +171,22 @@ async function getUsersFromCsv(d2, file, csv, { maxUsers }) {
     const columnNames = _.first(csv.data);
     const rows = maxUsers ? _(csv.data).drop(1).take(maxUsers).value() : _(csv.data).drop(1).value();
 
+    const plainUserAttributes = _(d2.models.users.modelValidations)
+        .map((value, key) => _(["TEXT", "DATE", "URL"]).includes(value.type) ? key : null)
+        .compact()
+        .value();
+
+    const knownColumnNames = _(columnNameFromPropertyMapping)
+        .keys()
+        .union(plainUserAttributes)
+        .value();
+
     // Column properties can be human names (propertyFromColumnNameMapping) or direct key values
     const columnMapping = _(columnNames)
         .map(columnName => [
             columnName,
             propertyFromColumnNameMapping[columnName] ||
-                (_(columnNameFromPropertyMapping).keys().includes(columnName) ? columnName : undefined)
+                (_(knownColumnNames).includes(columnName) ? columnName : undefined)
         ])
         .fromPairs()
         .value();
@@ -188,7 +199,7 @@ async function getUsersFromCsv(d2, file, csv, { maxUsers }) {
         : csvColumnProperties;
 
     const validColumnProperties = _(columnProperties)
-        .intersection(_.keys(columnNameFromPropertyMapping))
+        .intersection(knownColumnNames)
         .difference(propertiesIgnoredOnImport)
         .value();
 

--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -182,15 +182,12 @@ async function getUsersFromCsv(d2, file, csv, { maxUsers }) {
         .value();
 
     // Column properties can be human names (propertyFromColumnNameMapping) or direct key values
-    const columnMapping = _(columnNames)
-        .map(columnName => [
-            columnName,
+    const csvColumnProperties = _(columnNames)
+        .map(columnName =>
             propertyFromColumnNameMapping[columnName] ||
-                (_(knownColumnNames).includes(columnName) ? columnName : undefined)
-        ])
-        .fromPairs()
+                (_(knownColumnNames).includes(columnName) ? columnName : undefined))
         .value();
-    const csvColumnProperties = _(columnMapping).values().value();
+    const columnMapping = _(columnNames).zip(csvColumnProperties).fromPairs().value();
 
     // Insert password column after username if not found
     const usernameIdx = csvColumnProperties.indexOf("username");


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #122 

### :memo: Implementation

- Field phoneNumber added as known column.
- Show human header name if it's a known column, the plain key otherwise.
- Use `d2.models.users.modelValidations` to get extra plain fields for users: `["birthday", "education", "gender", "jobTitle", "employer", "introduction", "languages", "nationality", "interests"]`
- Extra commit: Allow repeated column names (the last one is used).

### :art: Screenshots

![screenshot from 2018-11-14 14-33-45](https://user-images.githubusercontent.com/24643/48485941-72f12480-e81a-11e8-87af-84e6e64f8356.png)

