### PR TITLE
Fix error parsing on metadata post catch

### DIFF
--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -341,7 +341,7 @@ function postMetadata(api, payload) {
     return api
         .post("metadata?importStrategy=CREATE_AND_UPDATE&mergeMode=REPLACE", payload)
         .then(res => parseResponse(res, payload))
-        .catch(error => ({ success: false, error }));
+        .catch(error => ({ success: false, payload, error: error && error.message || error.toString() }));
     }
 
 /* Public interface */


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes #137 

### :memo: Implementation

- Dhis2 `metadata` endpoint returns two kind of errors: 1) a full detailed error JSON, 2) a simple object with just a string about the problem (for example: `{"httpStatus":"Internal Server Error","httpStatusCode":500,"status":"ERROR","message":"Invalid format: \"asd\""}`). The first kind is already processed, the last is the one which has been fixed.

### :art: Screenshots

![Screenshot from 2018-12-10 11-07-19.png](https://waffleio-direct-uploads-production.s3.amazonaws.com/uploads/57022c2f494d000e00432e8e/125516c66e82c728ace21e0d46db978826878dba87e6ab03a24fff99691477227149f2793dd4b368ee13365158424fa553444d04bea6d37ef5f22e7a985959b880640c71c53e15a9bbd016bf00bc258b4682e5b98c5edcfa7f74b9dfd0126754505a9bf54f37a0934acd5cf24fe24b52a4153166e0647b.png)