### PR TITLE
Do not export last login date if not defined

### DIFF
--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -138,7 +138,7 @@ function collectionFromNames(user, rowIndex, field, objectsByName) {
 function getPlainUser(user, { orgUnitsField }) {
     const userCredentials = user.userCredentials || {};
 
-    return _.compact({
+    return {
         ...user,
         username: userCredentials.username,
         lastUpdated: formatDate(user.lastUpdated),
@@ -148,7 +148,7 @@ function getPlainUser(user, { orgUnitsField }) {
         userGroups: namesFromCollection(user.userGroups, "displayName"),
         organisationUnits: namesFromCollection(user.organisationUnits, orgUnitsField),
         dataViewOrganisationUnits: namesFromCollection(user.dataViewOrganisationUnits, orgUnitsField),
-    });
+    };
 }
 
 function getPlainUserFromRow(user, modelValuesByField, rowIndex) {

--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -111,7 +111,7 @@ function getColumnNameFromProperty(property) {
 }
 
 function formatDate(stringDate) {
-    return moment(stringDate).format("YYYY-MM-DD HH:mm:ss");
+    return !!stringDate ? moment(stringDate).format("YYYY-MM-DD HH:mm:ss") : null;
 }
 
 function parseDate(stringDate) {
@@ -138,7 +138,7 @@ function collectionFromNames(user, rowIndex, field, objectsByName) {
 function getPlainUser(user, { orgUnitsField }) {
     const userCredentials = user.userCredentials || {};
 
-    return {
+    return _.compact({
         ...user,
         username: userCredentials.username,
         lastUpdated: formatDate(user.lastUpdated),
@@ -148,7 +148,7 @@ function getPlainUser(user, { orgUnitsField }) {
         userGroups: namesFromCollection(user.userGroups, "displayName"),
         organisationUnits: namesFromCollection(user.organisationUnits, orgUnitsField),
         dataViewOrganisationUnits: namesFromCollection(user.dataViewOrganisationUnits, orgUnitsField),
-    };
+    });
 }
 
 function getPlainUserFromRow(user, modelValuesByField, rowIndex) {


### PR DESCRIPTION
* **Issue:** Closes #143 

HWF (NHWA) users complained that the lastLogin date was defaulting to the same day of the export, this was happening because we were executing ```moment(undefined)``` which creates a ```new Date()```.

This fixes this issue for lastLogin, lastUpdated and created fields.