### PR TITLE
Show existing OU in replicate user

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2-user-extended-app",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "DHIS2 Extended User app",
   "main": "src/index.html",
   "license": "GPL-3.0",

--- a/src/components/ImportTable.component.js
+++ b/src/components/ImportTable.component.js
@@ -459,6 +459,7 @@ class ImportTable extends React.Component {
                 surname: templateUser.attributes.surname,
                 organisationUnits: templateUser.attributes.organisationUnits,
                 dataViewOrganisationUnits: templateUser.attributes.dataViewOrganisationUnits,
+                email: templateUser.attributes.email,
             };
         } else {
             newUser = {

--- a/src/components/ImportTable.component.js
+++ b/src/components/ImportTable.component.js
@@ -457,6 +457,8 @@ class ImportTable extends React.Component {
                 password: `District123_${index}`,
                 firstName: templateUser.attributes.firstName,
                 surname: templateUser.attributes.surname,
+                organisationUnits: templateUser.attributes.organisationUnits,
+                dataViewOrganisationUnits: templateUser.attributes.dataViewOrganisationUnits,
             };
         } else {
             newUser = {

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -85,7 +85,12 @@ class User {
 
     static async getById(d2, userId) {
         const api = d2.Api.getApi();
-        const userAttributes = await api.get(`/users/${userId}`, { fields: ":all" });
+        const userAttributes = await api.get(`/users/${userId}`, {
+            fields:
+                ":all," +
+                "organisationUnits[id,code,displayName,path]," +
+                "dataViewOrganisationUnits[id,code,displayName,path]",
+        });
         return new User(d2, userAttributes);
     }
 }


### PR DESCRIPTION
### 🏷 Implementation

- Add to ``User.getById`` the fields of organisationUnits attributes
- Send to component templateUser's ```organisationUnits``` and ```dataViewOrganisationUnits``` attributes.

### 🎨 Screenshots

![image](https://user-images.githubusercontent.com/2181866/64708994-c9b8a080-d4b5-11e9-80c2-1cd13835f16b.png)

### 🏛 Build (release zip)

[User-Extended-App.zip](https://github.com/EyeSeeTea/user-extended-app/files/3601456/User-Extended-App.zip)
