### PR TITLE
[HWF] Fix issue when filter includes too much users

### DIFF
--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -34,7 +34,7 @@ const queryFields = [
     Limit Uids to avoid 413 Request too large
     maxUids = (maxSize - urlAndOtherParamsSize) / (uidSize + encodedCommaSize)
 */
-const maxUids = (8192 - 1000) / (11 + 3);
+const maxUids = (4096 - 1000) / (11 + 3);
 
 const requiredPropertiesOnImport = ["username", "password", "firstName", "surname"];
 
@@ -517,12 +517,14 @@ function getList(d2, filters, listOptions) {
 
     const listFilters = buildD2Filter(normalFilters.concat(preliminarFilters));
 
-    if (d2.system.version.minor >= 30) return model.list({
-        paging: true,
-        fields: queryFields,
-        filter: _(listFilters).isEmpty() ? "name:ne:default" : listFilters,
-        ...listOptions,
-    });
+    if (d2.system.version.minor >= 30) {
+        return model.list({
+            paging: true,
+            fields: queryFields,
+            filter: _(listFilters).isEmpty() ? "name:ne:default" : listFilters,
+            ...listOptions,
+        });
+    }
 
     const preliminarD2Filters$ = preliminarFilters.map(preliminarFilter =>
         model

--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -515,9 +515,8 @@ function getList(d2, filters, listOptions) {
         ([key, [operator, value]]) => operator === "in" && key.match(/\./)
     );
 
-    const listFilters = buildD2Filter(normalFilters.concat(preliminarFilters));
-
     if (d2.system.version.minor >= 30) {
+        const listFilters = buildD2Filter(normalFilters.concat(preliminarFilters));
         return model.list({
             paging: true,
             fields: queryFields,

--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -514,6 +514,16 @@ function getList(d2, filters, listOptions) {
         activeFilters,
         ([key, [operator, value]]) => operator === "in" && key.match(/\./)
     );
+
+    const listFilters = buildD2Filter(normalFilters.concat(preliminarFilters));
+
+    if (d2.system.version.minor >= 30) return model.list({
+        paging: true,
+        fields: queryFields,
+        filter: _(listFilters).isEmpty() ? "name:ne:default" : listFilters,
+        ...listOptions,
+    });
+
     const preliminarD2Filters$ = preliminarFilters.map(preliminarFilter =>
         model
             .list({


### PR DESCRIPTION
- The original code had a work-around to make the request work in DHIS2 version pre 2.30
- Yet the work-around introduces a bug when there are too many users included in the filtering
- Also from my testing it appears that the work-around does not work as expected

*Temporal fix*

- If version is 2.30+, ignore the work-around and proceed with a bug-less request

*Open discussion*

- How do we properly fix this?
- Was the work-around really needed?

*For context*

```
/*  Filtering over nested fields (table[.table].field) in N-to-N relationships (for
        example: userCredentials.userRoles.id), fails in dhis2 < v2.30. So we need to make
        separate calls to the API for those filters and use the returned IDs to build
        the final, paginated call. */
```