### PR TITLE
Check for correct authority with replicate user

### DIFF
--- a/src/List/context.actions.js
+++ b/src/List/context.actions.js
@@ -79,10 +79,10 @@ function isStateActionVisible(action) {
         _(users).some(user => user.disabled === requiredDisabledValue);
 }
 
-function isAdmin(rows) {
+function hasReplicateAuthority(rows) {
     if (rows && rows.length > 0) {
         const { authorities } = rows[0].d2.currentUser;
-        return authorities.has("ALL");
+        return authorities.has("F_REPLICATE_USER");
     } else {
         return false;
     }
@@ -155,7 +155,7 @@ const contextActions = [
         name: "replicateUser",
         icon: "content_copy",
         multiple: false,
-        allowed: isAdmin,
+        allowed: hasReplicateAuthority,
         items: [
             {
                 name: "replicate_user_from_template",


### PR DESCRIPTION
Tested with one user and removed in another tab the authorities and it appears to be working fine os far. The change is very small and more restrictive than what we had before.