### PR TITLE
Do not clear collections on import

### DIFF
--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -58,8 +58,8 @@ const columnNameFromPropertyMapping = {
     created: "Created",
     userRoles: "Roles",
     userGroups: "Groups",
-    organisationUnits: "OUOutput",
-    dataViewOrganisationUnits: "OUCapture",
+    organisationUnits: "OUCapture",
+    dataViewOrganisationUnits: "OUOutput",
 };
 
 const propertyFromColumnNameMapping = _.invert(columnNameFromPropertyMapping);

--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -162,10 +162,12 @@ function collectionFromNames(user, rowIndex, field, objectsByName) {
             `Value not found: ${missingValue} [username=${username ||
                 "-"} csv-row=${rowIndex} csv-column=${field}]`
     );
-    const objects = _(objectsByName)
-        .at(names)
-        .compact()
-        .value();
+    const objects = objectsByName
+        ? _(objectsByName)
+              .at(names)
+              .compact()
+              .value()
+        : undefined;
     return { objects, warnings };
 }
 

--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -150,8 +150,8 @@ function namesFromCollection(collection, field) {
 }
 
 function collectionFromNames(user, rowIndex, field, objectsByName) {
-    const namesString = user[field];
-    const names = (namesString || "")
+    const value = user[field];
+    const names = (value || "")
         .split(fieldSplitChar)
         .map(_.trim)
         .filter(s => s);
@@ -162,7 +162,7 @@ function collectionFromNames(user, rowIndex, field, objectsByName) {
             `Value not found: ${missingValue} [username=${username ||
                 "-"} csv-row=${rowIndex} csv-column=${field}]`
     );
-    const objects = objectsByName
+    const objects = value && objectsByName
         ? _(objectsByName)
               .at(names)
               .compact()


### PR DESCRIPTION
### Description

This was hard to debug, even though our logic manually merged the CSV built user with the existing user during import, we had a bug with collections (userGroups/userRoles/organisationUnits/dataViewOrganisationUnits) that were defaulting to an empty collection instead of undefined.

### Steps to reproduce

- Export some users without "Organisation Units" column
- Import these users

**Expected behavior**

- Users should have kept the original organisation unit assignment

**Actual behavior**

- Users have lost their assignment to the organisation unit

NOTE: The case where you have the column and no OU assigned has always worked