### PR TITLE
Do not clear lastLogin date on updating user roles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2-user-extended-app",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "DHIS2 Extended User app",
   "main": "src/index.html",
   "license": "GPL-3.0",

--- a/src/components/UserRolesDialog.component.js
+++ b/src/components/UserRolesDialog.component.js
@@ -28,7 +28,7 @@ function UserRolesDialog(props, context) {
 
     const modelOptions = {
         parentModel: d2.models.users,
-        parentFields: ":owner,userCredentials[id,username,userRoles[id,name]]",
+        parentFields: ":owner,userCredentials[id,username,userRoles[id,name],lastLogin]",
         childrenModel: d2.models.userRoles,
         getChildren: user => user.userCredentials.userRoles,
         getPayload: getPayload,


### PR DESCRIPTION
### References

* **Issue:** Closes #167 

### Steps to reproduce

- Add column "last login" to table (to see the bug happening)
- Select an user that has previously logged in
- Do any change in the user roles (assign a new one for example)
- The user's last login date has been cleared from the database

### Implementation

- Fetch lastLogin field as "parent" and use it in the resulting user payload

### Notes

- The current implementation uses a REPLACE strategy but we do not fetch all properties (So not only lastLogin but other fields might get lost.
- Since "it is working" just fine for now I would not touch it more than this.
- If we have time, a more robust approach could be implemented but it would require some hours.