### PR TITLE
Use organisation units short name

### DIFF
--- a/app-config/app-config.example.json
+++ b/app-config/app-config.example.json
@@ -7,7 +7,7 @@
                 "background": "#3c3c3c"
             }
         },
-        "showShareButton": true,
+        "showShareButton": true
     },
     "feedback": {
         "token": ["03242fc6b0c5a48582", "2e6b8d3e8337b5a0b95fe2"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2-user-extended-app",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "description": "DHIS2 Extended User app",
   "main": "src/index.html",
   "license": "GPL-3.0",

--- a/src/App/appStateStore.js
+++ b/src/App/appStateStore.js
@@ -42,6 +42,12 @@ async function loadSideBarState() {
         );
 }
 
+// d2/src/current-user/CurrentUser.js#getOrganisationUnits + children[shortName]
+const orgUnitListOptions = {
+    fields: ':all,shortName,displayName,path,children[id,shortName,displayName,path,children::isNotEmpty]',
+    paging: false,
+}
+
 // TODO: Move the caching of these organisation units to d2.currentUser instead
 async function getCurrentUserOrganisationUnits(disableCache = false) {
     if (!disableCache && getCurrentUserOrganisationUnits.currentUserOrganisationUnits) {
@@ -49,10 +55,10 @@ async function getCurrentUserOrganisationUnits(disableCache = false) {
     }
 
     const d2 = await getInstance();
-    const organisationUnitsCollection = await d2.currentUser.getOrganisationUnits();
+    const organisationUnitsCollection = await d2.currentUser.getOrganisationUnits(orgUnitListOptions);
 
     if (d2.currentUser.authorities.has("ALL") && !organisationUnitsCollection.size) {
-        const rootLevelOrgUnits = await d2.models.organisationUnits.list({ level: 1 });
+        const rootLevelOrgUnits = await d2.models.organisationUnits.list({ ...orgUnitListOptions, level: 1 });
 
         getCurrentUserOrganisationUnits.currentUserOrganisationUnits = rootLevelOrgUnits;
 

--- a/src/List/List.component.js
+++ b/src/List/List.component.js
@@ -360,6 +360,7 @@ const List = React.createClass({
                 <ReplicateComponent
                     userToReplicateId={info.user.id}
                     onRequestClose={this.onReplicateDialogClose}
+                    settings={this.state.settings}
                 />
             );
         } else {
@@ -589,6 +590,7 @@ const List = React.createClass({
                         columns={importUsers.columns}
                         warnings={importUsers.warnings}
                         maxUsers={this.maxImportUsers}
+                        settings={this.state.settings}
                     />
                 )}
             </div>

--- a/src/List/context.actions.js
+++ b/src/List/context.actions.js
@@ -14,7 +14,7 @@ async function assignToOrgUnits(selectedUsers, field, titleKey) {
     const userIds = selectedUsers.map(u => u.model.id);
     const listOptions = {
         paging: false,
-        fields: `:owner,${field}[id,path,displayName]`,
+        fields: `:owner,${field}[id,path,shortName,displayName]`,
         filter: `id:in:[${userIds.join(",")}]`,
     };
     const users = (await d2.models.users.list(listOptions)).toArray();

--- a/src/components/ImportTable.component.js
+++ b/src/components/ImportTable.component.js
@@ -401,19 +401,24 @@ class ImportTable extends React.Component {
             "dataViewOrganisationUnits",
         ];
 
+        const orgUnitsField = this.props.settings.get("organisationUnitsField");
+
         return this.getColumns().map(field => {
             const value = user[field];
             const validators = (this.fieldsInfo[field] || this.fieldsInfo._default).validators;
             const isMultipleValue = relationshipFields.includes(field);
+            const displayField = field === "organisationUnits" || field === "dataViewOrganisationUnits"
+                ? orgUnitsField
+                : "displayName";
 
             if (isMultipleValue) {
                 const values = value || [];
                 const compactValue = _(values).isEmpty()
                     ? "-"
                     : `[${values.length}] ` +
-                      getCompactTextForModels(this.context.d2, values, { limit: 1 });
+                      getCompactTextForModels(this.context.d2, values, { limit: 1, field: displayField });
                 const hoverText = _(values)
-                    .map("displayName")
+                    .map(displayField)
                     .join(", ");
                 const onClick = this.getOnTextFieldClicked(user.id, field);
 
@@ -741,6 +746,7 @@ ImportTable.propTypes = {
     actionText: PropTypes.string.isRequired,
     columns: PropTypes.arrayOf(PropTypes.string).isRequired,
     warnings: PropTypes.arrayOf(PropTypes.string),
+    settings: PropTypes.object.isRequired,
 };
 
 ImportTable.defaultProps = {

--- a/src/components/OrgUnitForm.js
+++ b/src/components/OrgUnitForm.js
@@ -36,12 +36,12 @@ class OrgUnitForm extends React.Component {
         Promise.all([
             d2.models.organisationUnitLevels.list({
                 paging: false,
-                fields: "id,level,displayName,path",
+                fields: "id,level,displayName,shortName,path",
                 order: "level:asc",
             }),
             d2.models.organisationUnitGroups.list({
                 paging: false,
-                fields: "id,displayName,path",
+                fields: "id,displayName,shortName,path",
             }),
         ]).then(([levels, groups]) => {
             this.setState({
@@ -63,7 +63,7 @@ class OrgUnitForm extends React.Component {
                         .on("displayName")
                         .ilike(searchValue)
                         .list({
-                            fields: "id,displayName,path,children::isNotEmpty",
+                            fields: "id,displayName,shortName,path,children::isNotEmpty",
                             withinUserHierarchy: true,
                         })
                         .then(modelCollection => modelCollection.toArray());
@@ -85,7 +85,7 @@ class OrgUnitForm extends React.Component {
         const orgUnitIds = orgUnitsPaths.map(path => _.last(path.split("/")));
         const newSelected = await listWithInFilter(d2.models.organisationUnits, "id", orgUnitIds, {
             paging: false,
-            fields: "id,displayName,path",
+            fields: "id,displayName,shortName,path",
         });
 
         this.props.onChange(newSelected);
@@ -93,7 +93,7 @@ class OrgUnitForm extends React.Component {
 
     toggleOrgUnit(ev, orgUnitModel) {
         const orgUnit = _(orgUnitModel)
-            .pick(["id", "path", "displayName"])
+            .pick(["id", "shortName", "path", "displayName"])
             .value();
         const newSelected = _(this.props.selected).find(
             selectedOu => selectedOu.path === orgUnit.path

--- a/src/components/ReplicateUserFromTable.component.js
+++ b/src/components/ReplicateUserFromTable.component.js
@@ -69,6 +69,7 @@ class ReplicateUserFromTable extends React.Component {
                 actionText={this.t("replicate")}
                 onRequestClose={onRequestClose}
                 columns={this.columns}
+                settings={this.props.settings}
             />
         );
     }
@@ -81,6 +82,7 @@ ReplicateUserFromTable.contextTypes = {
 ReplicateUserFromTable.propTypes = {
     userToReplicateId: PropTypes.string.isRequired,
     onRequestClose: PropTypes.func.isRequired,
+    settings: PropTypes.object.isRequired,
 };
 
 export default ReplicateUserFromTable;

--- a/src/components/ReplicateUserFromTemplate.component.js
+++ b/src/components/ReplicateUserFromTemplate.component.js
@@ -249,6 +249,7 @@ ReplicateUserFromTemplate.contextTypes = {
 ReplicateUserFromTemplate.propTypes = {
     userToReplicateId: PropTypes.string.isRequired,
     onRequestClose: PropTypes.func.isRequired,
+    settings: PropTypes.object,
 };
 
 export default ReplicateUserFromTemplate;

--- a/src/i18n/i18n_module_ar.properties
+++ b/src/i18n/i18n_module_ar.properties
@@ -39,6 +39,7 @@ id=الهوية
 last_updated=Last updated
 last_login=Last login
 name=Name
+short_name=Short name
 code=Code
 first_name=First name
 surname=Surname

--- a/src/i18n/i18n_module_en.properties
+++ b/src/i18n/i18n_module_en.properties
@@ -39,6 +39,7 @@ id=Id
 last_updated=Last updated
 last_login=Last login
 name=Name
+short_name=Short name
 code=Code
 first_name=First name
 surname=Surname

--- a/src/i18n/i18n_module_es.properties
+++ b/src/i18n/i18n_module_es.properties
@@ -39,6 +39,7 @@ id=Id
 last_updated=Última actualización
 last_login=Último login
 name=Nombre
+short_name=Nombre corto
 code=Código
 first_name=Nombre
 surname=Apellidos

--- a/src/i18n/i18n_module_fr.properties
+++ b/src/i18n/i18n_module_fr.properties
@@ -39,6 +39,7 @@ id=Id
 last_updated=Dernière mise à jour
 last_login=Last login
 name=Name
+short_name=Short name
 code=Code
 first_name=First name
 surname=Surname

--- a/src/models/settings.js
+++ b/src/models/settings.js
@@ -14,8 +14,17 @@ class Settings {
     constructor(d2, values) {
         this.d2 = d2;
         this.api = d2.Api.getApi();
-        this.values = values;
         this.fields = Settings.getFields(d2);
+        this.values = Settings.validateValues(values, this.fields);
+    }
+
+    static validateValues(values, fields) {
+        // Set the default value for a setting with a value not present in the options list.
+        return _.mapValues(values, (value, key) => {
+            const { options, defaultValue } = fields[key] || {};
+            if (!options || !defaultValue) return value;
+            return _(options).some(option => option.value === value) ? value : defaultValue;
+        });
     }
 
     static getFields(d2) {
@@ -41,9 +50,9 @@ class Settings {
                 name: "organisationUnitsField",
                 type: "select",
                 label: t("setting_organisation_units_field"),
-                defaultValue: "displayName",
+                defaultValue: "shortName",
                 options: [
-                    { text: t("name"), value: "displayName" },
+                    { text: t("short_name"), value: "shortName" },
                     { text: t("code"), value: "code" },
                 ],
             },

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -88,8 +88,8 @@ class User {
         const userAttributes = await api.get(`/users/${userId}`, {
             fields:
                 ":all," +
-                "organisationUnits[id,code,displayName,path]," +
-                "dataViewOrganisationUnits[id,code,displayName,path]",
+                "organisationUnits[id,code,shortName,displayName,path]," +
+                "dataViewOrganisationUnits[id,code,shortName,displayName,path]",
         });
         return new User(d2, userAttributes);
     }


### PR DESCRIPTION
Closes #177 
Requires https://github.com/EyeSeeTea/d2-ui/pull/28

Notes:

- Use only `orgUnit.shortName` except for importing, where we match both by shortName and displayName (this way old csv export files will still work)
- A user with a setting orgUnitField="displayName" will now show "shortName" without a need for migration (as it's the default value). 