### PR TITLE
Add option to copy data view and data capture org unit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2-user-extended-app",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "DHIS2 Extended User app",
   "main": "src/index.html",
   "license": "GPL-3.0",

--- a/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.component.js
+++ b/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.component.js
@@ -22,6 +22,8 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
             updateStrategy: this.props.parents.length > 1 ? "merge" : "replace",
             copyUserGroups: false,
             copyUserRoles: false,
+            orgUnitOutput: false,
+            orgUnits: false,
         };
     }
 
@@ -58,14 +60,29 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
         cancelButton: {
             marginRight: 16,
         },
-        toggle: {
-            width: 135,
+        userGroupsToggle: {
+            width: 145,
+            marginTop: 10,
+            marginRight: 5,
             float: "right",
-            marginTop: 20,
-            marginRight: 50,
+        },
+        userRolesToggle: {
+            width: 135,
+            marginTop: 10,
+            marginRight: 60,
+            float: "right",
+        },
+        orgUnitToggle: {
+            width: 125,
+            marginRight: 65,
+            float: "right",
+        },
+        orgUnitOutputToggle: {
+            width: 140,
+            float: "right",
+            marginRight: 5,
         },
     };
-
     componentDidMount() {
         const { parents, model } = this.props;
         return Promise.all([model.getAllChildren(), model.getParents(parents)])
@@ -110,10 +127,24 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
     }
 
     async copyInUserSave() {
-        const { parents, selectedIds, copyUserGroups, copyUserRoles } = this.state;
+        const {
+            parents,
+            selectedIds,
+            copyUserGroups,
+            copyUserRoles,
+            orgUnitOutput,
+            orgUnits,
+        } = this.state;
         this.setState({ state: "loading" });
         await this.props.model
-            .copyInUserSave(parents, selectedIds, copyUserGroups, copyUserRoles)
+            .copyInUserSave(
+                parents,
+                selectedIds,
+                copyUserGroups,
+                copyUserRoles,
+                orgUnitOutput,
+                orgUnits
+            )
             .then(() => this.close(this.props.onSuccess))
             .catch(err => this.close(this.props.onError))
             .finally(() => this.setState({ state: "ready" }));
@@ -206,16 +237,30 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
 
                 <Toggle
                     label={"User Groups"}
-                    style={this.styles.toggle}
+                    style={this.styles.userGroupsToggle}
                     checked={this.state.copyUserGroups == true}
                     onToggle={(ev, newValue) => this.setState({ copyUserGroups: newValue })}
                 />
                 <Toggle
                     label={"User Roles"}
-                    style={this.styles.toggle}
+                    style={this.styles.userRolesToggle}
                     checked={this.state.copyUserRoles === true}
                     onToggle={(ev, newValue) => this.setState({ copyUserRoles: newValue })}
                 />
+                <div>
+                    <Toggle
+                        label={"OU Outputs"}
+                        style={this.styles.orgUnitOutputToggle}
+                        checked={this.state.orgUnitOutput === true}
+                        onToggle={(ev, newValue) => this.setState({ orgUnitOutput: newValue })}
+                    />
+                    <Toggle
+                        label={"Org Units"}
+                        style={this.styles.orgUnitToggle}
+                        checked={this.state.orgUnits == true}
+                        onToggle={(ev, newValue) => this.setState({ orgUnits: newValue })}
+                    />
+                </div>
                 <div style={this.styles.contents}>
                     <MultiSelect
                         isLoading={isLoading}

--- a/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.component.js
+++ b/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.component.js
@@ -22,8 +22,8 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
             updateStrategy: this.props.parents.length > 1 ? "merge" : "replace",
             copyUserGroups: false,
             copyUserRoles: false,
-            orgUnitOutput: false,
-            orgUnits: false,
+            copyOrgUnitOutput: false,
+            copyOrgUnits: false,
         };
     }
 
@@ -77,7 +77,7 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
             marginRight: 65,
             float: "right",
         },
-        orgUnitOutputToggle: {
+        copyOrgUnitOutputToggle: {
             width: 140,
             float: "right",
             marginRight: 5,
@@ -132,19 +132,18 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
             selectedIds,
             copyUserGroups,
             copyUserRoles,
-            orgUnitOutput,
-            orgUnits,
+            copyOrgUnitOutput,
+            copyOrgUnits,
         } = this.state;
         this.setState({ state: "loading" });
+        const copyAccessElements = {
+            userGroups: copyUserGroups,
+            userRoles: copyUserRoles,
+            orgUnitOutput: copyOrgUnitOutput,
+            orgUnits: copyOrgUnits,
+        };
         await this.props.model
-            .copyInUserSave(
-                parents,
-                selectedIds,
-                copyUserGroups,
-                copyUserRoles,
-                orgUnitOutput,
-                orgUnits
-            )
+            .copyInUserSave(parents, selectedIds, copyAccessElements)
             .then(() => this.close(this.props.onSuccess))
             .catch(err => this.close(this.props.onError))
             .finally(() => this.setState({ state: "ready" }));
@@ -176,9 +175,15 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
     }
 
     copy() {
-        const { copyUserGroups, copyUserRoles, selectedIds } = this.state;
+        const {
+            copyUserGroups,
+            copyUserRoles,
+            copyOrgUnitOutput,
+            copyOrgUnits,
+            selectedIds,
+        } = this.state;
 
-        if (!copyUserGroups && !copyUserRoles) {
+        if (!copyUserGroups && !copyUserRoles && !copyOrgUnitOutput && !copyOrgUnits) {
             snackActions.show({ message: this.getTranslation("select_one_toggle") });
         } else if (_.isEmpty(selectedIds)) {
             snackActions.show({ message: this.getTranslation("select_at_least_one_user") });
@@ -250,15 +255,15 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
                 <div>
                     <Toggle
                         label={"OU Outputs"}
-                        style={this.styles.orgUnitOutputToggle}
-                        checked={this.state.orgUnitOutput === true}
-                        onToggle={(ev, newValue) => this.setState({ orgUnitOutput: newValue })}
+                        style={this.styles.copyOrgUnitOutputToggle}
+                        checked={this.state.copyOrgUnitOutput === true}
+                        onToggle={(ev, newValue) => this.setState({ copyOrgUnitOutput: newValue })}
                     />
                     <Toggle
                         label={"Org Units"}
                         style={this.styles.orgUnitToggle}
-                        checked={this.state.orgUnits == true}
-                        onToggle={(ev, newValue) => this.setState({ orgUnits: newValue })}
+                        checked={this.state.copyOrgUnits == true}
+                        onToggle={(ev, newValue) => this.setState({ copyOrgUnits: newValue })}
                     />
                 </div>
                 <div style={this.styles.contents}>

--- a/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.model.js
+++ b/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.model.js
@@ -49,23 +49,14 @@ export default class CopyInUserBatchModelsMultiSelectModel {
         });
         return users;
     }
-    async copyInUserSave(
-        parents,
-        selectedIds,
-        copyUserGroups,
-        copyUserRoles,
-        orgUnitOutput,
-        orgUnits
-    ) {
+    async copyInUserSave(parents, selectedIds, copyAccessElements) {
         const parentWithRoles = await this.getUserInfo([getOwnedPropertyJSON(parents[0]).id]);
         const childrenUsers = await this.getUserInfo(selectedIds);
+
         const payload = await this.getPayload(
             ...parentWithRoles,
             childrenUsers,
-            copyUserGroups,
-            copyUserRoles,
-            orgUnitOutput,
-            orgUnits
+            copyAccessElements
         );
         return payload;
     }

--- a/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.model.js
+++ b/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.model.js
@@ -49,14 +49,23 @@ export default class CopyInUserBatchModelsMultiSelectModel {
         });
         return users;
     }
-    async copyInUserSave(parents, selectedIds, copyUserGroups, copyUserRoles) {
+    async copyInUserSave(
+        parents,
+        selectedIds,
+        copyUserGroups,
+        copyUserRoles,
+        orgUnitOutput,
+        orgUnits
+    ) {
         const parentWithRoles = await this.getUserInfo([getOwnedPropertyJSON(parents[0]).id]);
         const childrenUsers = await this.getUserInfo(selectedIds);
         const payload = await this.getPayload(
             ...parentWithRoles,
             childrenUsers,
             copyUserGroups,
-            copyUserRoles
+            copyUserRoles,
+            orgUnitOutput,
+            orgUnits
         );
         return payload;
     }

--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -638,10 +638,13 @@ async function getExistingUsers(d2, options = {}) {
     return users;
 }
 
-function getPayload(parentUser, destUsers, copyUserGroups, copyUserRoles) {
+function getPayload(parentUser, destUsers, copyUserGroups, copyUserRoles, orgUnitOutput, orgUnits) {
     const users = destUsers.map(childUser => {
         let childUserRoles = childUser.userCredentials.userRoles;
         let childUserGroups = childUser.userGroups;
+        let childOrgUnitOutput = childUser.dataViewOrganisationUnits;
+        let childOrgUnits = childUser.organisationUnits;
+
         if (copyUserRoles) {
             parentUser.userCredentials.userRoles.forEach(role => {
                 if (childUserRoles.find(element => element.id === role.id) === undefined) {
@@ -653,6 +656,23 @@ function getPayload(parentUser, destUsers, copyUserGroups, copyUserRoles) {
             parentUser.userGroups.forEach(group => {
                 if (childUserGroups.find(element => element.id === group.id) === undefined) {
                     childUserGroups.push(group);
+                }
+            });
+        }
+        if (orgUnitOutput) {
+            parentUser.dataViewOrganisationUnits.forEach(dataViewOrgUnit => {
+                if (
+                    childOrgUnitOutput.find(element => element.id === dataViewOrgUnit.id) ===
+                    undefined
+                ) {
+                    childOrgUnitOutput.push(dataViewOrgUnit);
+                }
+            });
+        }
+        if (orgUnits) {
+            parentUser.organisationUnits.forEach(dataOrgUnit => {
+                if (childOrgUnits.find(element => element.id === dataOrgUnit.id) === undefined) {
+                    childOrgUnits.push(dataOrgUnit);
                 }
             });
         }

--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -638,64 +638,55 @@ async function getExistingUsers(d2, options = {}) {
     });
     return users;
 }
-function addItems(childUserElement, parentUserElement, accessElement) {
-    if (!accessElement) {
-        return childUserElement;
+function addItems(items1, items2, shouldAdd) {
+    if (!shouldAdd) {
+        return items1;
     } else {
-        return _(childUserElement)
-            .unionBy(parentUserElement, element => element.id)
+        return _(items1)
+            .unionBy(items2, element => element.id)
             .value();
     }
 }
 
-function getPayload(parentUser, destUsers, copyAccessElements) {
+function getPayload(parentUser, destUsers, fields) {
     const users = destUsers.map(childUser => {
-        const childUserRoles = childUser.userCredentials.userRoles;
-        const parentUserRoles = parentUser.userCredentials.userRoles;
-
-        const childUserGroups = childUser.userGroups;
-        const parentUserGroups = parentUser.userGroups;
-
-        const childOrgUnitOutput = childUser.dataViewOrganisationUnits;
-        const parentOrgUnitOutput = parentUser.dataViewOrganisationUnits;
-
-        const childOrgUnits = childUser.organisationUnits;
-        const parentOrgUnits = parentUser.organisationUnits;
-
         const newChildUserCredentials = {
             ...childUser.userCredentials,
-            userRoles: addItems(childUserRoles, parentUserRoles, copyAccessElements.userRoles),
+            userRoles: addItems(
+                childUser.userCredentials.userRoles,
+                parentUser.userCredentials.userRoles,
+                fields.userRoles
+            ),
         };
 
         const newChildUserGroups = addItems(
-            childUserGroups,
-            parentUserGroups,
-            copyAccessElements.userGroups
+            childUser.userGroups,
+            parentUser.userGroups,
+            fields.userGroups
         );
 
-        const newChildOrgUnitOutput = addItems(
-            childOrgUnitOutput,
-            parentOrgUnitOutput,
-            copyAccessElements.orgUnitOutput
+        const newChildOrgUnitsOutput = addItems(
+            childUser.dataViewOrganisationUnits,
+            parentUser.dataViewOrganisationUnits,
+            fields.orgUnitOutput
         );
 
         const newChildOrgUnits = addItems(
-            childOrgUnits,
-            parentOrgUnits,
-            copyAccessElements.orgUnits
+            childUser.organisationUnits,
+            parentUser.organisationUnits,
+            fields.orgUnits
         );
 
-        const newChildUser = {
+        return {
             ...childUser,
             userCredentials: newChildUserCredentials,
             userGroups: newChildUserGroups,
-            dataViewOrganisationUnits: newChildOrgUnitOutput,
+            dataViewOrganisationUnits: newChildOrgUnitsOutput,
             organisationUnits: newChildOrgUnits,
         };
-
-        return newChildUser;
     });
-    return saveCopyInUsers(d2, users, copyAccessElements.userGroups);
+
+    return saveCopyInUsers(d2, users, fields.userGroups);
 }
 
 export {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes "Add option to copy data view and data capture org unit" in ClickUp (CU-d112tv)

### :memo: Implementation (orgUnits and OU Outputs Toggle)
- Added 2 new toggles for orgUnits and OU Outputs
- added a boolean for the toggles to pass it to the copyInUserSave function 
- Extended the getPayload function to copy over orgUnits in the same fashion as userGroups and userRoles

### :art: Screenshots
<img width="1255" alt="Screen Shot 2021-01-26 at 12 12 35 PM" src="https://user-images.githubusercontent.com/20975863/105838016-cdc46000-5fcf-11eb-8552-89546a7d58d1.png">



### :fire: Testing