### PR TITLE
Workaround for paging error when filtering by group

### DIFF
--- a/src/List/Filters.component.js
+++ b/src/List/Filters.component.js
@@ -119,8 +119,9 @@ export default class Filters extends React.Component {
 
         const inFilter = field => (_(field).isEmpty() ? null : ["in", field]);
 
-        let returnObj = {
+        return {
             ...(showOnlyManagedUsers ? { canManage: "true" } : {}),
+            ...(searchString ? { query: searchString } : {}),
             filters: {
                 "userCredentials.disabled": showOnlyActiveUsers ? ["eq", false] : undefined,
                 "userCredentials.userRoles.id": inFilter(userRoles),
@@ -129,8 +130,6 @@ export default class Filters extends React.Component {
                 "dataViewOrganisationUnits.id": inFilter(orgUnitsOutput.map(ou => ou.id)),
             },
         };
-
-        return searchString ? { ...returnObj, query: searchString } : returnObj;
     }
 
     clearFilters = () => {

--- a/src/List/Filters.component.js
+++ b/src/List/Filters.component.js
@@ -119,8 +119,7 @@ export default class Filters extends React.Component {
 
         const inFilter = field => (_(field).isEmpty() ? null : ["in", field]);
 
-        return {
-            query: searchString,
+        let returnObj = {
             ...(showOnlyManagedUsers ? { canManage: "true" } : {}),
             filters: {
                 "userCredentials.disabled": showOnlyActiveUsers ? ["eq", false] : undefined,
@@ -130,6 +129,8 @@ export default class Filters extends React.Component {
                 "dataViewOrganisationUnits.id": inFilter(orgUnitsOutput.map(ou => ou.id)),
             },
         };
+
+        return searchString ? { ...returnObj, query: searchString } : returnObj;
     }
 
     clearFilters = () => {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes ["Paging error filtering by group"](https://app.clickup.com/t/dn075t) in ClickUp  and issue [#41](https://github.com/EyeSeeTea/user-extended-app-blessed/issues/41)

### :memo: Implementation 
- The issue was that in the API call if there was no searchString in the query it would only return the first page of results instead of all results so I just changed it so that if there is a searchString you add the query param else don't

### :art: Screenshots
For this example now it shows all 60 users instead of stopping at 50, the page limit 
<img width="1275" alt="Screen Shot 2021-02-09 at 11 03 22 AM" src="https://user-images.githubusercontent.com/20975863/107348007-bfde0700-6ac6-11eb-989f-caf6c37cbe11.png">

<img width="1275" alt="Screen Shot 2021-02-09 at 10 56 35 AM" src="https://user-images.githubusercontent.com/20975863/107346886-81941800-6ac5-11eb-82ef-4293b170839e.png">




### :fire: Testing