### PR TITLE
Add strategy to copy in user feature. 

### DIFF
--- a/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.component.js
+++ b/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.component.js
@@ -201,21 +201,6 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
             />,
         ];
     }
-    /*
-    <Toggle
-                    label={"Merge"}
-                    style={this.styles.strategyToggle}
-                    checked={this.state.copyUserGroups == true}
-                    onToggle={(ev, newValue) => this.setState({ copyUserGroups: newValue })}
-                />
-                <Toggle
-                    label={"Replace"}
-                    style={this.styles.strategyToggle}
-                    checked={this.state.copyUserRoles === true}
-                    onToggle={(ev, newValue) => this.setState({ copyUserRoles: newValue })}
-                />
-
-    */
 
     render() {
         const isLoading = this.state.state === "loading";

--- a/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.component.js
+++ b/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.component.js
@@ -19,7 +19,7 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
             allChildren: null,
             selectedIds: null,
             filterText: "",
-            updateStrategy: this.props.parents.length > 1 ? "merge" : "replace",
+            updateStrategy: this.props.parents.length === 1 ? "merge" : "replace",
             copyUserGroups: false,
             copyUserRoles: false,
             copyOrgUnitOutput: false,
@@ -60,27 +60,23 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
         cancelButton: {
             marginRight: 16,
         },
-        userGroupsToggle: {
+        column1Toggle: {
             width: 145,
-            marginTop: 10,
-            marginRight: 5,
-            float: "right",
         },
-        userRolesToggle: {
+        column2Toggle: {
             width: 135,
+        },
+        strategyToggle: {
+            width: 85,
             marginTop: 10,
-            marginRight: 60,
+            marginRight: 10,
             float: "right",
         },
-        orgUnitToggle: {
-            width: 125,
-            marginRight: 65,
-            float: "right",
+        flexContainer: {
+            display: "flex",
         },
-        copyOrgUnitOutputToggle: {
-            width: 140,
-            float: "right",
-            marginRight: 5,
+        ColumnTwo: {
+            marginLeft: 20,
         },
     };
     componentDidMount() {
@@ -105,25 +101,20 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
     }
 
     renderStrategyToggle() {
-        if (this.state.parents && this.state.parents.length > 1) {
-            const label =
-                this.getTranslation("update_strategy") +
-                ": " +
-                this.getTranslation("update_strategy_" + this.state.updateStrategy);
-
-            return (
-                <Toggle
-                    label={label}
-                    style={this.styles.toggle}
-                    checked={this.state.updateStrategy === "replace"}
-                    onToggle={(ev, newValue) =>
-                        this.setState({ updateStrategy: newValue ? "replace" : "merge" })
-                    }
-                />
-            );
-        } else {
-            return null;
-        }
+        const label =
+            this.getTranslation("update_strategy") +
+            ": " +
+            this.getTranslation("update_strategy_" + this.state.updateStrategy);
+        return (
+            <Toggle
+                label={label}
+                style={{ width: 280, float: "right", marginTop: 20, marginRight: 15 }}
+                checked={this.state.updateStrategy === "replace"}
+                onToggle={(ev, newValue) =>
+                    this.setState({ updateStrategy: newValue ? "replace" : "merge" })
+                }
+            />
+        );
     }
 
     async copyInUserSave() {
@@ -134,6 +125,7 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
             copyUserRoles,
             copyOrgUnitOutput,
             copyOrgUnits,
+            updateStrategy,
         } = this.state;
         this.setState({ state: "loading" });
         const copyAccessElements = {
@@ -143,7 +135,7 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
             orgUnits: copyOrgUnits,
         };
         await this.props.model
-            .copyInUserSave(parents, selectedIds, copyAccessElements)
+            .copyInUserSave(parents, selectedIds, copyAccessElements, updateStrategy)
             .then(() => this.close(this.props.onSuccess))
             .catch(err => this.close(this.props.onError))
             .finally(() => this.setState({ state: "ready" }));
@@ -209,6 +201,21 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
             />,
         ];
     }
+    /*
+    <Toggle
+                    label={"Merge"}
+                    style={this.styles.strategyToggle}
+                    checked={this.state.copyUserGroups == true}
+                    onToggle={(ev, newValue) => this.setState({ copyUserGroups: newValue })}
+                />
+                <Toggle
+                    label={"Replace"}
+                    style={this.styles.strategyToggle}
+                    checked={this.state.copyUserRoles === true}
+                    onToggle={(ev, newValue) => this.setState({ copyUserRoles: newValue })}
+                />
+
+    */
 
     render() {
         const isLoading = this.state.state === "loading";
@@ -240,32 +247,6 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
 
                 {this.renderStrategyToggle()}
 
-                <Toggle
-                    label={"User Groups"}
-                    style={this.styles.userGroupsToggle}
-                    checked={this.state.copyUserGroups == true}
-                    onToggle={(ev, newValue) => this.setState({ copyUserGroups: newValue })}
-                />
-                <Toggle
-                    label={"User Roles"}
-                    style={this.styles.userRolesToggle}
-                    checked={this.state.copyUserRoles === true}
-                    onToggle={(ev, newValue) => this.setState({ copyUserRoles: newValue })}
-                />
-                <div>
-                    <Toggle
-                        label={"OU Outputs"}
-                        style={this.styles.copyOrgUnitOutputToggle}
-                        checked={this.state.copyOrgUnitOutput === true}
-                        onToggle={(ev, newValue) => this.setState({ copyOrgUnitOutput: newValue })}
-                    />
-                    <Toggle
-                        label={"Org Units"}
-                        style={this.styles.orgUnitToggle}
-                        checked={this.state.copyOrgUnits == true}
-                        onToggle={(ev, newValue) => this.setState({ copyOrgUnits: newValue })}
-                    />
-                </div>
                 <div style={this.styles.contents}>
                     <MultiSelect
                         isLoading={isLoading}
@@ -274,6 +255,38 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
                         selected={selectedIds}
                         filterText={filterText}
                     />
+                </div>
+                <div style={this.styles.flexContainer}>
+                    <div>
+                        <Toggle
+                            label={"User Groups"}
+                            style={this.styles.column1Toggle}
+                            checked={this.state.copyUserGroups == true}
+                            onToggle={(ev, newValue) => this.setState({ copyUserGroups: newValue })}
+                        />
+                        <Toggle
+                            label={"OU Outputs"}
+                            style={this.styles.column1Toggle}
+                            checked={this.state.copyOrgUnitOutput === true}
+                            onToggle={(ev, newValue) =>
+                                this.setState({ copyOrgUnitOutput: newValue })
+                            }
+                        />
+                    </div>
+                    <div style={this.styles.ColumnTwo}>
+                        <Toggle
+                            label={"User Roles"}
+                            style={this.styles.column2Toggle}
+                            checked={this.state.copyUserRoles === true}
+                            onToggle={(ev, newValue) => this.setState({ copyUserRoles: newValue })}
+                        />
+                        <Toggle
+                            label={"Org Units"}
+                            style={this.styles.column2Toggle}
+                            checked={this.state.copyOrgUnits == true}
+                            onToggle={(ev, newValue) => this.setState({ copyOrgUnits: newValue })}
+                        />
+                    </div>
                 </div>
             </Dialog>
         );

--- a/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.model.js
+++ b/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.model.js
@@ -49,14 +49,15 @@ export default class CopyInUserBatchModelsMultiSelectModel {
         });
         return users;
     }
-    async copyInUserSave(parents, selectedIds, copyAccessElements) {
+    async copyInUserSave(parents, selectedIds, copyAccessElements, updateStrategy) {
         const parentWithRoles = await this.getUserInfo([getOwnedPropertyJSON(parents[0]).id]);
         const childrenUsers = await this.getUserInfo(selectedIds);
 
         const payload = await this.getPayload(
             ...parentWithRoles,
             childrenUsers,
-            copyAccessElements
+            copyAccessElements,
+            updateStrategy
         );
         return payload;
     }

--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -507,8 +507,13 @@ async function updateUsers(d2, users, mapper) {
     return postMetadata(api, payload);
 }
 
-/* Save array of users (plain attributes), updating existing one, creating new ones */
+async function getUserGroupsToSaveAndPostMetadata(api, users, existingUsersToUpdate) {
+    const userGroupsToSave = await getUserGroupsToSave(api, users, existingUsersToUpdate);
+    const payload = { users: users, userGroups: userGroupsToSave };
+    return postMetadata(api, payload);
+}
 
+/* Save array of users (plain attributes), updating existing one, creating new ones */
 async function saveUsers(d2, users) {
     const api = d2.Api.getApi();
     const existingUsersToUpdate = await getExistingUsers(d2, {
@@ -520,12 +525,8 @@ async function saveUsers(d2, users) {
                 .join(",") +
             "]",
     });
-    console.log();
     const usersToSave = getUsersToSave(users, existingUsersToUpdate);
-    const userGroupsToSave = await getUserGroupsToSave(api, usersToSave, existingUsersToUpdate);
-    const payload = { users: usersToSave, userGroups: userGroupsToSave };
-
-    return postMetadata(api, payload);
+    getUserGroupsToSaveAndPostMetadata(api, usersToSave, existingUsersToUpdate);
 }
 
 async function saveCopyInUsers(d2, users, copyUserGroups) {
@@ -540,9 +541,7 @@ async function saveCopyInUsers(d2, users, copyUserGroups) {
                     .join(",") +
                 "]",
         });
-        const userGroupsToSave = await getUserGroupsToSave(api, users, existingUsersToUpdate);
-        const payload = { users: users, userGroups: userGroupsToSave };
-        return postMetadata(api, payload);
+        return getUserGroupsToSaveAndPostMetadata(api, users, existingUsersToUpdate);
     } else {
         return postMetadata(api, { users: users });
     }

--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -520,6 +520,7 @@ async function saveUsers(d2, users) {
                 .join(",") +
             "]",
     });
+    console.log();
     const usersToSave = getUsersToSave(users, existingUsersToUpdate);
     const userGroupsToSave = await getUserGroupsToSave(api, usersToSave, existingUsersToUpdate);
     const payload = { users: usersToSave, userGroups: userGroupsToSave };


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes ["Add strategy to copy in user feature"](https://app.clickup.com/t/dn0840) in ClickUp

### :memo: Implementation 
- Added Replace/Merge toggle in top right and moved property toggles to bottom left
- In getPayload in userHelpers I passed the updateStrategy chosen to the addItems function so if it is chosen as "Replace" then it will just return the parent version of that property. 
- I then had to create a sort of new version of saveUsers in saveCopyInUsers where it got the existing users so it overrode their values.

### :art: Screenshots
<img width="1197" alt="Screen Shot 2021-02-11 at 3 38 29 PM" src="https://user-images.githubusercontent.com/20975863/107650893-d925b580-6c76-11eb-8140-bfa48add11f8.png">




### :fire: Testing