### PR TITLE
Add more descriptive information in copy in user

### DIFF
--- a/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.component.js
+++ b/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.component.js
@@ -210,9 +210,10 @@ export default class CopyInUserBatchModelsMultiSelectComponent extends React.Com
         const parentName = this.props.parents[0].name;
         const options = _(allChildren || [])
             .sortBy("name")
-            .map(obj => ({ value: obj.id, text: obj.name }))
+            .map(obj => ({ value: obj.id, text: `${obj.name} (${obj.userCredentials.username})` }))
             .filter(obj => obj.text !== parentName)
             .value();
+
         return (
             <Dialog
                 title={title}

--- a/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.model.js
+++ b/src/components/batch-models-multi-select/CopyInUserBatchModelsMultiSelect.model.js
@@ -14,7 +14,7 @@ export default class CopyInUserBatchModelsMultiSelectModel {
             parentFields: parentFields || ":owner",
             childrenModel: childrenModel,
             getChildren: parent => toArray(getChildren(parent)),
-            childrenFields: childrenFields || "id,name",
+            childrenFields: childrenFields || "id,name,userCredentials[username]",
             getPayload,
         });
     }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes ["Add more descriptive information in copy in user"](https://app.clickup.com/t/k56xzq) in ClickUp

### :memo: Implementation 
- Added "userCredentials[username] into childrenFields in CopyInUserBatchModelsMultiSelect.model and added it to the options array of objects so it would show in the users that you see in CopyInUser

### :art: Screenshots
![Screen Shot 2021-05-26 at 11 43 01 AM](https://user-images.githubusercontent.com/20975863/119639098-8df37500-be17-11eb-8941-054cd99a93df.png)



### :fire: How to test it? (If there is any special consideration or the reviewer does not know how to test it)