### PR TITLE
Refactor exportTemplateToCsv with custom columns

### DIFF
--- a/src/List/list.store.js
+++ b/src/List/list.store.js
@@ -9,7 +9,7 @@ import { getUserList } from "../models/userList";
 const orderForQuery = modelName =>
     modelName === "organisationUnitLevel" ? "level:ASC" : "name:iasc";
 
-const columns = [
+export const columns = [
     { name: "username", sortable: false },
     { name: "firstName", sortable: true },
     { name: "surname", sortable: true },

--- a/src/components/ImportExport.component.js
+++ b/src/components/ImportExport.component.js
@@ -11,7 +11,7 @@ import FileSaver from "file-saver";
 import moment from "moment";
 import fileDialog from "file-dialog";
 
-import { exportToCsv, importFromCsv } from "../models/userHelpers";
+import { exportToCsv, exportTemplateToCsv, importFromCsv } from "../models/userHelpers";
 import snackActions from "../Snackbar/snack.actions";
 import ModalLoadingMask from "./ModalLoadingMask.component";
 
@@ -77,13 +77,12 @@ class ImportExport extends React.Component {
         }
     };
 
-    exportEmptyTemplate = () => {
-        const { allColumns } = this.props;
+    exportEmptyTemplate = async () => {
         this.setState({ isProcessing: true });
 
         try {
-            const labeledColumns = allColumns.map(column => column.text);
-            this.saveCsv(labeledColumns, "empty-user-template");
+            const csvString = await exportTemplateToCsv(d2);
+            this.saveCsv(csvString, "empty-user-template");
         } finally {
             this.closeMenu();
             this.setState({ isProcessing: false });

--- a/src/components/OrgUnitsFilter.component.js
+++ b/src/components/OrgUnitsFilter.component.js
@@ -102,6 +102,7 @@ class OrgUnitsFilter extends React.Component {
     render() {
         const { title, styles } = this.props;
         const { dialogOpen, selected } = this.state;
+        const t = this.getTranslation.bind(this);
 
         return (
             <div style={this.styles.wrapper}>
@@ -122,13 +123,13 @@ class OrgUnitsFilter extends React.Component {
                         intersectionPolicy={true}
                         filteringByNameLabel={
                             title.includes("organisation units capture")
-                                ? "filter_organisation_units_capture_by_name"
-                                : "filter_organisation_units_output_by_name"
+                                ? t("filter_organisation_units_capture_by_name")
+                                : t("filter_organisation_units_output_by_name")
                         }
                         orgUnitsSelectedLabel={
                             title.includes("organisation units capture")
-                                ? "organisation_units_capture_selected"
-                                : "organisation_units_output_selected"
+                                ? t("organisation_units_capture_selected")
+                                : t("organisation_units_output_selected")
                         }
                     />
                 </Dialog>

--- a/src/models/userHelpers.js
+++ b/src/models/userHelpers.js
@@ -6,6 +6,7 @@ import { generateUid } from "d2/lib/uid";
 
 import { mapPromise, listWithInFilter } from "../utils/dhis2Helpers";
 import { getUserList } from "./userList";
+import { columns } from "../List/list.store";
 
 // Delimiter to use in multiple-value fields (roles, groups, orgUnits)
 const fieldSplitChar = "||";
@@ -28,7 +29,6 @@ const queryFields = [
     "organisationUnits[id,code,shortName,displayName]",
     "dataViewOrganisationUnits[id,code,shortName,displayName]",
 ].join(",");
-
 
 const requiredPropertiesOnImport = ["username", "password", "firstName", "surname"];
 
@@ -538,6 +538,23 @@ async function exportToCsv(d2, columns, filterOptions, { orgUnitsField }) {
     return Papa.unparse(table);
 }
 
+async function exportTemplateToCsv(d2) {
+    const columnsAdded = ["password"];
+    const columnsRemoved = ["lastUpdated", "created", "lastLogin"];
+    const columnKeysToExport = _(columns)
+        .map(column => column.name)
+        .difference(columnsRemoved)
+        .union(columnsAdded)
+        .value();
+    const header = _(columnKeysToExport)
+        .map(getColumnNameFromProperty)
+        .compact()
+        .value();
+    const table = [header];
+
+    return Papa.unparse(table);
+}
+
 async function importFromCsv(d2, file, { maxUsers, orgUnitsField }) {
     return new Promise((resolve, reject) => {
         Papa.parse(file, {
@@ -622,6 +639,7 @@ function getPayload(parentUser, destUsers, fields, updateStrategy) {
 
 export {
     exportToCsv,
+    exportTemplateToCsv,
     importFromCsv,
     updateUsers,
     saveUsers,


### PR DESCRIPTION
Closes https://app.clickup.com/t/md946f, https://app.clickup.com/t/md94hf

- [Export] exports only visible columns. 
- [Export template] exports all columns. Now, we add `password` and remove `["lastUpdated", "created", "lastLogin"]`, which don't seem to make much sense later when importing. It's easy to change: [here](https://github.com/EyeSeeTea/user-extended-app/pull/204/files#diff-cc9b1afc37b6e4370c7578a3cec9b843fa6a123d611bdd6876e78bc8b64e0ee0R543).
- Tested: On import, password column is used to build the import UI table.
- Fixed missing translations in orgUnits pop-up filters.