### PR TITLE
Use always custom query/filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2-user-extended-app",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "DHIS2 Extended User app",
   "main": "src/index.html",
   "license": "GPL-3.0",

--- a/src/models/userList.js
+++ b/src/models/userList.js
@@ -48,10 +48,6 @@ export async function getUserList(d2, filtersObject, listOptions) {
     const hasQuery = query !== "" || canManage !== undefined;
     const hasFilters = !_.isEmpty(filters);
 
-    if (!hasFilters) {
-        return getUserListStandard(d2, filtersObject, listOptions);
-    }
-
     const usersByQuery = hasQuery ? await getD2Users(d2, { query, canManage }) : null;
     const usersByFilters = hasFilters ? await getFilteredUsers(d2, filters) : null;
     const allUsers = !hasQuery && !hasFilters ? await getD2Users(d2, {}) : null;


### PR DESCRIPTION
Closes https://app.clickup.com/t/mn8uhh

The problem when page > 1 showing only 1 user forbids using the default DHIS2 call altogether. So we must use always custom queries, slower.