### PR TITLE
Feature/use filter as and or or

### DIFF
--- a/public/old-i18n/i18n_module_ar.properties
+++ b/public/old-i18n/i18n_module_ar.properties
@@ -134,4 +134,5 @@ select_one_toggle=You must select a toggle option
 select_at_least_one_user=Select at least one destination user
 AND=AND
 OR=OR
-Filtering_behavior=Filtering behavior 
+Filtering_behavior=Filtering behavior
+Active_in_advanced_only=(Only for advanced filters)

--- a/public/old-i18n/i18n_module_en.properties
+++ b/public/old-i18n/i18n_module_en.properties
@@ -134,4 +134,5 @@ select_one_toggle=You must select a toggle option
 select_at_least_one_user=Select at least one destination user
 AND=AND
 OR=OR
-Filtering_behavior=Filtering behavior 
+Filtering_behavior=Filtering behavior
+Active_in_advanced_only=(Only for advanced filters)

--- a/public/old-i18n/i18n_module_es.properties
+++ b/public/old-i18n/i18n_module_es.properties
@@ -136,3 +136,4 @@ select_at_least_one_user=Seleccione al menos un usuario destino
 AND=AND
 OR=OR
 Filtering_behavior=Tipo de filtrado
+Active_in_advanced_only=(Solo para los filtros avanzados)

--- a/public/old-i18n/i18n_module_fr.properties
+++ b/public/old-i18n/i18n_module_fr.properties
@@ -135,3 +135,4 @@ select_at_least_one_user=Select at least one destination user
 AND=AND
 OR=OR
 Filtering_behavior=Type de filtrage
+Active_in_advanced_only=(Pour les filtres avancées seulement)

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -38,6 +38,7 @@ export class UserD2ApiRepository implements UserRepository {
             filters,
         } = options;
         const otherFilters = _.mapValues(filters, items => (items ? { [items[0]]: items[1] } : undefined));
+        const areFiltersEnabled = _(otherFilters).values().some()
 
         return apiToFuture(
             this.api.models.users.get({
@@ -46,7 +47,7 @@ export class UserD2ApiRepository implements UserRepository {
                 pageSize,
                 query: search !== "" ? search : undefined,
                 filter: otherFilters,
-                rootJunction: filters ? rootJunction : undefined,
+                rootJunction: areFiltersEnabled ? rootJunction : undefined,
                 order: `${sorting.field}:${sorting.order}`,
             })
         ).map(({ objects, pager }) => ({

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -249,10 +249,10 @@ export class UserD2ApiRepository implements UserRepository {
     private toDomainUser(input: ApiUser): User {
         const { userCredentials, ...user } = input;
         const authorities =
-            _(userCredentials.userRoles?.map(userRole => userRole.authorities))
+            _(userCredentials.userRoles).map(userRole => userRole.authorities)
                 .flatten()
                 .uniq()
-                .value() || [];
+                .value();
 
         return {
             id: user.id,

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -247,10 +247,11 @@ export class UserD2ApiRepository implements UserRepository {
 
     private toDomainUser(input: ApiUser): User {
         const { userCredentials, ...user } = input;
-        const authorities = _(userCredentials.userRoles?.map(userRole => userRole.authorities))
-            .flatten()
-            .uniq()
-            .value() || [];
+        const authorities =
+            _(userCredentials.userRoles?.map(userRole => userRole.authorities))
+                .flatten()
+                .uniq()
+                .value() || [];
 
         return {
             id: user.id,

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -38,7 +38,7 @@ export class UserD2ApiRepository implements UserRepository {
             filters,
         } = options;
         const otherFilters = _.mapValues(filters, items => (items ? { [items[0]]: items[1] } : undefined));
-        const areFiltersEnabled = _(otherFilters).values().some()
+        const areFiltersEnabled = _(otherFilters).values().some();
 
         return apiToFuture(
             this.api.models.users.get({
@@ -248,11 +248,11 @@ export class UserD2ApiRepository implements UserRepository {
 
     private toDomainUser(input: ApiUser): User {
         const { userCredentials, ...user } = input;
-        const authorities =
-            _(userCredentials.userRoles).map(userRole => userRole.authorities)
-                .flatten()
-                .uniq()
-                .value();
+        const authorities = _(userCredentials.userRoles)
+            .map(userRole => userRole.authorities)
+            .flatten()
+            .uniq()
+            .value();
 
         return {
             id: user.id,

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -29,7 +29,14 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     public list(options: ListOptions): FutureData<PaginatedResponse<User>> {
-        const { page, pageSize, search, sorting = { field: "firstName", order: "asc" }, filters } = options;
+        const {
+            page,
+            pageSize,
+            search,
+            sorting = { field: "firstName", order: "asc" },
+            rootJunction,
+            filters,
+        } = options;
         const otherFilters = _.mapValues(filters, items => (items ? { [items[0]]: items[1] } : undefined));
 
         return apiToFuture(
@@ -39,6 +46,7 @@ export class UserD2ApiRepository implements UserRepository {
                 pageSize,
                 query: search !== "" ? search : undefined,
                 filter: otherFilters,
+                rootJunction: filters ? rootJunction : undefined,
                 order: `${sorting.field}:${sorting.order}`,
             })
         ).map(({ objects, pager }) => ({

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -247,10 +247,10 @@ export class UserD2ApiRepository implements UserRepository {
 
     private toDomainUser(input: ApiUser): User {
         const { userCredentials, ...user } = input;
-        const authorities = _(userCredentials.userRoles.map(userRole => userRole.authorities))
+        const authorities = _(userCredentials.userRoles?.map(userRole => userRole.authorities))
             .flatten()
             .uniq()
-            .value();
+            .value() || [];
 
         return {
             id: user.id,
@@ -269,7 +269,7 @@ export class UserD2ApiRepository implements UserRepository {
             userGroups: user.userGroups,
             username: userCredentials.username,
             apiUrl: `${this.api.baseUrl}/api/users/${user.id}.json`,
-            userRoles: userCredentials.userRoles.map(userRole => ({ id: userRole.id, name: userRole.name })),
+            userRoles: userCredentials.userRoles?.map(userRole => ({ id: userRole.id, name: userRole.name })) || [],
             lastLogin: userCredentials.lastLogin ? new Date(userCredentials.lastLogin) : undefined,
             disabled: userCredentials.disabled,
             organisationUnits: user.organisationUnits,

--- a/src/domain/repositories/UserRepository.ts
+++ b/src/domain/repositories/UserRepository.ts
@@ -22,6 +22,7 @@ export interface ListOptions {
     search?: string;
     sorting?: { field: string; order: "asc" | "desc" };
     filters?: ListFilters;
+    rootJunction?: "AND" | "OR";
 }
 
 export type ListFilterType = "in" | "eq";

--- a/src/legacy/List/Filters.component.js
+++ b/src/legacy/List/Filters.component.js
@@ -236,7 +236,7 @@ export default class Filters extends React.Component {
                             <Grid item xs={4} className="control-row switch">
                                 <span>{this.getTranslation("Filtering_behavior")}</span>
                                 <div className="control-switch">
-                                    <span>{this.getTranslation("AND")}</span>
+                                    <span>{this.getTranslation("OR")}</span>
                                     <Switch
                                         className="control-switch"
                                         onChange={() => {
@@ -245,7 +245,7 @@ export default class Filters extends React.Component {
                                         }}
                                         checked={rootJunction === "AND"}
                                     />
-                                    <span>{this.getTranslation("OR")}</span>
+                                    <span>{this.getTranslation("AND")}</span>
                                 </div>
                             </Grid>
                         </Grid>

--- a/src/legacy/List/Filters.component.js
+++ b/src/legacy/List/Filters.component.js
@@ -247,6 +247,7 @@ export default class Filters extends React.Component {
                                     />
                                     <span>{this.getTranslation("AND")}</span>
                                 </div>
+                                <span>{this.getTranslation("Active_in_advanced_only")}</span>
                             </Grid>
                         </Grid>
                         <div className="control-row">

--- a/src/legacy/List/Filters.component.js
+++ b/src/legacy/List/Filters.component.js
@@ -61,13 +61,13 @@ export default class Filters extends React.Component {
             searchStringClear: null,
             showOnlyManagedUsers: false,
             showOnlyActiveUsers: false,
-            rootJunction: false,
             userRoles: [],
             userGroups: [],
             orgUnits: [],
             orgUnitsOutput: [],
             userRolesAll: [],
             userGroupsAll: [],
+            rootJunction: "OR",
         };
     }
 
@@ -124,6 +124,7 @@ export default class Filters extends React.Component {
             userGroups,
             orgUnits,
             orgUnitsOutput,
+            rootJunction,
         } = this.state;
 
         const inFilter = field => (_(field).isEmpty() ? null : ["in", field]);
@@ -131,6 +132,7 @@ export default class Filters extends React.Component {
         return {
             ...(showOnlyManagedUsers ? { canManage: "true" } : {}),
             ...(searchString ? { query: searchString } : {}),
+            ...(rootJunction ? { rootJunction } : {}),
             filters: {
                 "userCredentials.disabled": showOnlyActiveUsers ? ["eq", false] : undefined,
                 "userCredentials.userRoles.id": inFilter(userRoles),
@@ -217,7 +219,7 @@ export default class Filters extends React.Component {
                 >
                     <div style={{ padding: 10, margin: 10 }}>
                         <Grid container spacing={2} className="control-row">
-                            <Grid item xs={6} className="control-row checkboxes">
+                            <Grid item xs={8} className="control-row checkboxes">
                                 <Checkbox
                                     className="control-checkbox"
                                     label={this.getTranslation("display_only_users_can_manage")}
@@ -231,14 +233,17 @@ export default class Filters extends React.Component {
                                     checked={showOnlyActiveUsers}
                                 />
                             </Grid>
-                            <Grid item xs={6} className="control-row switch">
+                            <Grid item xs={4} className="control-row switch">
                                 <span>{this.getTranslation("Filtering_behavior")}</span>
                                 <div className="control-switch">
                                     <span>{this.getTranslation("AND")}</span>
                                     <Switch
                                         className="control-switch"
-                                        onChange={this.setFilter("rootJunction", this.checkboxHandler)}
-                                        checked={rootJunction}
+                                        onChange={() => {
+                                            const newRootJunction = (rootJunction === "AND" ? "OR" : "AND");
+                                            this.setState({ rootJunction: newRootJunction }, this.notifyParent);
+                                        }}
+                                        checked={rootJunction === "AND"}
                                     />
                                     <span>{this.getTranslation("OR")}</span>
                                 </div>

--- a/src/legacy/List/Filters.component.js
+++ b/src/legacy/List/Filters.component.js
@@ -240,7 +240,7 @@ export default class Filters extends React.Component {
                                     <Switch
                                         className="control-switch"
                                         onChange={() => {
-                                            const newRootJunction = (rootJunction === "AND" ? "OR" : "AND");
+                                            const newRootJunction = rootJunction === "AND" ? "OR" : "AND";
                                             this.setState({ rootJunction: newRootJunction }, this.notifyParent);
                                         }}
                                         checked={rootJunction === "AND"}

--- a/src/legacy/List/List.component.js
+++ b/src/legacy/List/List.component.js
@@ -325,6 +325,7 @@ export class ListHybrid extends React.Component {
                             loading={this.state.isLoading}
                             openSettings={this._openSettings}
                             filters={this.state.filters?.filters}
+                            rootJunction={this.state.filters?.rootJunction}
                             onChangeVisibleColumns={this._updateVisibleColumns}
                         >
                             <Filters onChange={this._onFiltersChange} showSearch={false} api={this.props.api} />
@@ -360,7 +361,7 @@ export class ListHybrid extends React.Component {
                 ) : null}
 
                 {this.state.orgunitassignment.open &&
-                this.state.orgunitassignment.field === "dataViewOrganisationUnits" ? (
+                    this.state.orgunitassignment.field === "dataViewOrganisationUnits" ? (
                     <OrgUnitDialog
                         api={this.props.api}
                         models={this.state.orgunitassignment.users}

--- a/src/legacy/List/List.component.js
+++ b/src/legacy/List/List.component.js
@@ -361,7 +361,7 @@ export class ListHybrid extends React.Component {
                 ) : null}
 
                 {this.state.orgunitassignment.open &&
-                    this.state.orgunitassignment.field === "dataViewOrganisationUnits" ? (
+                this.state.orgunitassignment.field === "dataViewOrganisationUnits" ? (
                     <OrgUnitDialog
                         api={this.props.api}
                         models={this.state.orgunitassignment.users}

--- a/src/webapp/components/user-list-table/UserListTable.tsx
+++ b/src/webapp/components/user-list-table/UserListTable.tsx
@@ -32,6 +32,7 @@ export const UserListTable: React.FC<UserListTableProps> = ({
     openSettings,
     onChangeVisibleColumns,
     filters,
+    rootJunction,
     children,
 }) => {
     const { compositionRoot, currentUser } = useAppContext();
@@ -64,7 +65,7 @@ export const UserListTable: React.FC<UserListTableProps> = ({
 
             onChangeVisibleColumns(columns);
             compositionRoot.users.saveColumns(columns).run(
-                () => {},
+                () => { },
                 error => snackbar.error(error)
             );
         },
@@ -246,11 +247,11 @@ export const UserListTable: React.FC<UserListTableProps> = ({
                     pageSize,
                     sorting,
                     filters,
-                    rootJunction: "OR",   // TODO: get from the Filters component
+                    rootJunction,
                 })
                 .toPromise();
         },
-        [compositionRoot, filters, reloadKey]
+        [compositionRoot, filters, rootJunction, reloadKey]
     );
 
     const refreshAllIds = useCallback(
@@ -366,6 +367,7 @@ function isStateActionVisible(action: string) {
 export interface UserListTableProps extends Pick<ObjectsTableProps<User>, "loading"> {
     openSettings: () => void;
     filters: ListFilters;
+    rootJunction: "AND" | "OR";
     onChangeVisibleColumns: (columns: string[]) => void;
 }
 

--- a/src/webapp/components/user-list-table/UserListTable.tsx
+++ b/src/webapp/components/user-list-table/UserListTable.tsx
@@ -246,6 +246,7 @@ export const UserListTable: React.FC<UserListTableProps> = ({
                     pageSize,
                     sorting,
                     filters,
+                    rootJunction: "OR",   // TODO: get from the Filters component
                 })
                 .toPromise();
         },

--- a/src/webapp/components/user-list-table/UserListTable.tsx
+++ b/src/webapp/components/user-list-table/UserListTable.tsx
@@ -65,7 +65,7 @@ export const UserListTable: React.FC<UserListTableProps> = ({
 
             onChangeVisibleColumns(columns);
             compositionRoot.users.saveColumns(columns).run(
-                () => { },
+                () => {},
                 error => snackbar.error(error)
             );
         },


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/22k4dbc

### :memo: Implementation

Depending on the direction of the new AND/OR switch gui element, it sets a `rootJunction` property that can be "AND" or "OR", and then it uses it when making the call to `compositionRoot.users.list()`.

### :art: Screenshots

Some filters added in **OR** mode:

![Screenshot from 2022-06-23 14-55-33](https://user-images.githubusercontent.com/1568405/175303720-7789470e-19fb-49ba-9322-007b24382be3.png)

When changing the same filters to **AND** mode:

![Screenshot from 2022-06-23 14-55-42](https://user-images.githubusercontent.com/1568405/175303740-81e4c8c8-ff97-45c0-8c72-c1b90d4364ea.png)

### :fire: Testing
