### PR TITLE
Bugfix/broken group and roles dialog for import

### DIFF
--- a/public/old-i18n/i18n_module_ar.properties
+++ b/public/old-i18n/i18n_module_ar.properties
@@ -1,5 +1,6 @@
 actions=Actions
 assign_all=Assign all
+remove_all=Remove all
 assign_groups=Assign to groups
 assign_roles=Assign roles
 assign_to_org_units_capture=Assign to organisation units capture

--- a/public/old-i18n/i18n_module_ar.properties
+++ b/public/old-i18n/i18n_module_ar.properties
@@ -1,4 +1,5 @@
 actions=Actions
+selected=selected
 assign_all=Assign all
 remove_all=Remove all
 assign_groups=Assign to groups

--- a/public/old-i18n/i18n_module_en.properties
+++ b/public/old-i18n/i18n_module_en.properties
@@ -1,5 +1,6 @@
 actions=Actions
 assign_all=Assign all
+remove_all=Remove all
 assign_groups=Assign to groups
 assign_roles=Assign roles
 assign_to_org_units_capture=Assign to organisation units capture

--- a/public/old-i18n/i18n_module_en.properties
+++ b/public/old-i18n/i18n_module_en.properties
@@ -1,4 +1,5 @@
 actions=Actions
+selected=selected
 assign_all=Assign all
 remove_all=Remove all
 assign_groups=Assign to groups

--- a/public/old-i18n/i18n_module_es.properties
+++ b/public/old-i18n/i18n_module_es.properties
@@ -1,4 +1,5 @@
 actions=Acciones
+selected=seleccionado(s)
 assign_all=Assignar todos
 remove_all=Eliminar todos
 assign_groups=Asignar a grupos

--- a/public/old-i18n/i18n_module_es.properties
+++ b/public/old-i18n/i18n_module_es.properties
@@ -1,5 +1,6 @@
 actions=Acciones
 assign_all=Assignar todos
+remove_all=Eliminar todos
 assign_groups=Asignar a grupos
 assign_roles=Asignar a roles
 assign_to_org_units_capture=Asignar a la captura de unidades organizativas

--- a/public/old-i18n/i18n_module_fr.properties
+++ b/public/old-i18n/i18n_module_fr.properties
@@ -1,5 +1,6 @@
 actions=Actions
 assign_all=Assign all
+remove_all=Supprimer tout
 assign_groups=Assign to groups
 assign_roles=Assign roles
 assign_to_org_units_capture=Assign to organisation units capture

--- a/public/old-i18n/i18n_module_fr.properties
+++ b/public/old-i18n/i18n_module_fr.properties
@@ -1,4 +1,5 @@
 actions=Actions
+selected=sélectionné(s)
 assign_all=Assign all
 remove_all=Supprimer tout
 assign_groups=Assign to groups

--- a/src/legacy/components/MultipleSelector.component.js
+++ b/src/legacy/components/MultipleSelector.component.js
@@ -3,6 +3,9 @@ import React from "react";
 import PropTypes from "prop-types";
 import OrgUnitForm from "./OrgUnitForm";
 import _ from "lodash";
+
+import FilteredMultiSelect from "./FilteredMultiSelect.component";
+
 class MultipleSelector extends React.Component {
     constructor(props, context) {
         super(props, context);
@@ -57,11 +60,25 @@ class MultipleSelector extends React.Component {
     };
 
     renderForm = () => {
-        const { field, orgUnitRoots } = this.props;
+        const { field, options, orgUnitRoots } = this.props;
         const { selected } = this.state;
         const t = this.getTranslation.bind(this);
 
         switch (field) {
+            case "userGroups":
+            case "userRoles": {
+                const selectOptions = options.map(o => ({ value: o.id, text: o.displayName }));
+                const selectedIds = _(selected).map("id").value();
+
+                return (
+                    <FilteredMultiSelect
+                        options={selectOptions}
+                        selected={selectedIds}
+                        onRequestClose={this.closeDialog}
+                        onChange={this.onMultiSelectChange}
+                    />
+                );
+            }
             case "organisationUnits":
                 return (
                     <OrgUnitForm


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** [[User-Extended] fix groups and roles popup on intermediate screen for import](https://app.clickup.com/t/2jm5d42)

### :memo: Implementation

The code for _userGroups_ and _userRoles_ was removed, i guess in order to migrate to the newer components.
Given that this [issue](https://app.clickup.com/t/2f1wzrc) will update the import dialog, i will reuse the old code for the fix.

Also some missing translations were added.

### :fire: Testing

No new code was added, only re-added old code, only functional testing should be needed.
