### PR TITLE
Bugfix/"Display only users I can manage" filter not working

### DIFF
--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -29,7 +29,7 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     public list(options: ListOptions): FutureData<PaginatedResponse<User>> {
-        const { page, pageSize, search, sorting = { field: "firstName", order: "asc" }, filters } = options;
+        const { page, pageSize, search, sorting = { field: "firstName", order: "asc" }, filters, canManage } = options;
         const otherFilters = _.mapValues(filters, items => (items ? { [items[0]]: items[1] } : undefined));
 
         return apiToFuture(
@@ -38,6 +38,7 @@ export class UserD2ApiRepository implements UserRepository {
                 page,
                 pageSize,
                 query: search !== "" ? search : undefined,
+                canManage: canManage !== false ? true : undefined,
                 filter: otherFilters,
                 order: `${sorting.field}:${sorting.order}`,
             })
@@ -48,7 +49,7 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     public listAllIds(options: ListOptions): FutureData<string[]> {
-        const { search, sorting = { field: "firstName", order: "asc" }, filters } = options;
+        const { search, sorting = { field: "firstName", order: "asc" }, filters, canManage } = options;
         const otherFilters = _.mapValues(filters, items => (items ? { [items[0]]: items[1] } : undefined));
 
         return apiToFuture(
@@ -56,6 +57,7 @@ export class UserD2ApiRepository implements UserRepository {
                 fields: { id: true },
                 paging: false,
                 query: search !== "" ? search : undefined,
+                canManage: canManage !== false ? true : undefined,
                 filter: otherFilters,
                 order: `${sorting.field}:${sorting.order}`,
             })
@@ -155,9 +157,9 @@ export class UserD2ApiRepository implements UserRepository {
                     userRoles:
                         strategy === "merge"
                             ? _.uniqBy(
-                                  [..._.differenceBy(user.userRoles, commonRoles, ({ id }) => id), ...update],
-                                  ({ id }) => id
-                              )
+                                [..._.differenceBy(user.userRoles, commonRoles, ({ id }) => id), ...update],
+                                ({ id }) => id
+                            )
                             : update,
                 };
             });
@@ -179,9 +181,9 @@ export class UserD2ApiRepository implements UserRepository {
                     userGroups:
                         strategy === "merge"
                             ? _.uniqBy(
-                                  [..._.differenceBy(user.userGroups, commonGroups, ({ id }) => id), ...update],
-                                  ({ id }) => id
-                              )
+                                [..._.differenceBy(user.userGroups, commonGroups, ({ id }) => id), ...update],
+                                ({ id }) => id
+                            )
                             : update,
                 };
             });

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -38,7 +38,7 @@ export class UserD2ApiRepository implements UserRepository {
                 page,
                 pageSize,
                 query: search !== "" ? search : undefined,
-                canManage: canManage !== false ? true : undefined,
+                canManage: canManage === "true" ? "true" : undefined,
                 filter: otherFilters,
                 order: `${sorting.field}:${sorting.order}`,
             })
@@ -57,7 +57,7 @@ export class UserD2ApiRepository implements UserRepository {
                 fields: { id: true },
                 paging: false,
                 query: search !== "" ? search : undefined,
-                canManage: canManage !== false ? true : undefined,
+                canManage: canManage === "true" ? "true" : undefined,
                 filter: otherFilters,
                 order: `${sorting.field}:${sorting.order}`,
             })

--- a/src/domain/repositories/UserRepository.ts
+++ b/src/domain/repositories/UserRepository.ts
@@ -22,6 +22,7 @@ export interface ListOptions {
     search?: string;
     sorting?: { field: string; order: "asc" | "desc" };
     filters?: ListFilters;
+    canManage?: boolean;
 }
 
 export type ListFilterType = "in" | "eq";

--- a/src/domain/repositories/UserRepository.ts
+++ b/src/domain/repositories/UserRepository.ts
@@ -22,7 +22,7 @@ export interface ListOptions {
     search?: string;
     sorting?: { field: string; order: "asc" | "desc" };
     filters?: ListFilters;
-    canManage?: boolean;
+    canManage?: string;
 }
 
 export type ListFilterType = "in" | "eq";

--- a/src/legacy/List/List.component.js
+++ b/src/legacy/List/List.component.js
@@ -289,7 +289,6 @@ export class ListHybrid extends React.Component {
     };
 
     _onFiltersChange = filters => {
-        this.setState({ filters }, this.filterList);
         const canManage = filters.canManage;
         this.setState({ filters, canManage }, this.filterList);
     };

--- a/src/legacy/List/List.component.js
+++ b/src/legacy/List/List.component.js
@@ -290,6 +290,8 @@ export class ListHybrid extends React.Component {
 
     _onFiltersChange = filters => {
         this.setState({ filters }, this.filterList);
+        const canManage = filters.canManage;
+        this.setState({ filters, canManage }, this.filterList);
     };
 
     _disableUsersSaved = () => this.setUsersEnableState(this.state.disableUsers.users, this.state.disableUsers.action);
@@ -325,6 +327,7 @@ export class ListHybrid extends React.Component {
                             loading={this.state.isLoading}
                             openSettings={this._openSettings}
                             filters={this.state.filters?.filters}
+                            canManage={this.state?.canManage}
                             onChangeVisibleColumns={this._updateVisibleColumns}
                         >
                             <Filters onChange={this._onFiltersChange} showSearch={false} api={this.props.api} />

--- a/src/webapp/components/user-list-table/UserListTable.tsx
+++ b/src/webapp/components/user-list-table/UserListTable.tsx
@@ -368,7 +368,7 @@ function isStateActionVisible(action: string) {
 export interface UserListTableProps extends Pick<ObjectsTableProps<User>, "loading"> {
     openSettings: () => void;
     filters: ListFilters;
-    canManage: boolean;
+    canManage: string;
     onChangeVisibleColumns: (columns: string[]) => void;
 }
 

--- a/src/webapp/components/user-list-table/UserListTable.tsx
+++ b/src/webapp/components/user-list-table/UserListTable.tsx
@@ -32,6 +32,7 @@ export const UserListTable: React.FC<UserListTableProps> = ({
     openSettings,
     onChangeVisibleColumns,
     filters,
+    canManage,
     children,
 }) => {
     const { compositionRoot, currentUser } = useAppContext();
@@ -246,10 +247,11 @@ export const UserListTable: React.FC<UserListTableProps> = ({
                     pageSize,
                     sorting,
                     filters,
+                    canManage,
                 })
                 .toPromise();
         },
-        [compositionRoot, filters, reloadKey]
+        [compositionRoot, filters, canManage, reloadKey]
     );
 
     const refreshAllIds = useCallback(
@@ -259,10 +261,11 @@ export const UserListTable: React.FC<UserListTableProps> = ({
                     search,
                     sorting,
                     filters,
+                    canManage,
                 })
                 .toPromise();
         },
-        [compositionRoot, filters]
+        [compositionRoot, filters, canManage]
     );
 
     const tableProps = useObjectsTable(baseConfig, refreshRows, refreshAllIds);
@@ -365,6 +368,7 @@ function isStateActionVisible(action: string) {
 export interface UserListTableProps extends Pick<ObjectsTableProps<User>, "loading"> {
     openSettings: () => void;
     filters: ListFilters;
+    canManage: boolean;
     onChangeVisibleColumns: (columns: string[]) => void;
 }
 

--- a/src/webapp/components/user-list-table/UserListTable.tsx
+++ b/src/webapp/components/user-list-table/UserListTable.tsx
@@ -233,12 +233,28 @@ export const UserListTable: React.FC<UserListTableProps> = ({
     }, [openSettings, enableReplicate, editUsers, onReorderColumns, reload, navigate]);
 
     const refreshRows = useCallback(
-        (
+        async (
             search: string,
             { page, pageSize }: TablePagination,
             sorting: TableSorting<User>
         ): Promise<{ objects: User[]; pager: Pager }> => {
             console.debug("Reloading", reloadKey);
+
+            // SEE: src/legacy/models/userList.js LINE 29+
+            if (canManage === "true") {
+                const userIdList = await compositionRoot.users
+                .listAllIds({
+                    search,
+                    sorting,
+                    filters,
+                    canManage,
+                })
+                .toPromise();
+
+                if (userIdList) {
+                    filters["id"] = ["in", userIdList]
+                }
+            }
 
             return compositionRoot.users
                 .list({

--- a/src/webapp/components/user-list-table/UserListTable.tsx
+++ b/src/webapp/components/user-list-table/UserListTable.tsx
@@ -242,30 +242,26 @@ export const UserListTable: React.FC<UserListTableProps> = ({
 
             // SEE: src/legacy/models/userList.js LINE 29+
             if (canManage === "true") {
-                const userIdList = await compositionRoot.users
-                .listAllIds({
+                const userIdList = await compositionRoot.users.listAllIds({
                     search,
                     sorting,
                     filters,
                     canManage,
-                })
-                .toPromise();
+                }).toPromise();
 
                 if (userIdList) {
-                    filters["id"] = ["in", userIdList]
+                    filters["id"] = ["in", userIdList];
                 }
             }
 
-            return compositionRoot.users
-                .list({
+            return compositionRoot.users.list({
                     search,
                     page,
                     pageSize,
                     sorting,
                     filters,
                     canManage,
-                })
-                .toPromise();
+                }).toPromise();
         },
         [compositionRoot, filters, canManage, reloadKey]
     );


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** https://app.clickup.com/t/2jefv4d

### :memo: Implementation

Added the `canManage` query and fixed the user list paging issues (the total users value updated inconsistently). 
