### PR TITLE
Bugfix/open id export import not working

### DIFF
--- a/public/old-i18n/i18n_module_ar.properties
+++ b/public/old-i18n/i18n_module_ar.properties
@@ -135,3 +135,4 @@ select_at_least_one_user=Select at least one destination user
 AND=AND
 OR=OR
 Filtering_behavior=Filtering behavior 
+open_id=Open ID

--- a/public/old-i18n/i18n_module_en.properties
+++ b/public/old-i18n/i18n_module_en.properties
@@ -135,3 +135,4 @@ select_at_least_one_user=Select at least one destination user
 AND=AND
 OR=OR
 Filtering_behavior=Filtering behavior 
+open_id=Open ID

--- a/public/old-i18n/i18n_module_es.properties
+++ b/public/old-i18n/i18n_module_es.properties
@@ -136,3 +136,4 @@ select_at_least_one_user=Seleccione al menos un usuario destino
 AND=AND
 OR=OR
 Filtering_behavior=Tipo de filtrado
+open_id=Open ID

--- a/public/old-i18n/i18n_module_fr.properties
+++ b/public/old-i18n/i18n_module_fr.properties
@@ -135,3 +135,4 @@ select_at_least_one_user=Select at least one destination user
 AND=AND
 OR=OR
 Filtering_behavior=Type de filtrage
+open_id=Open ID

--- a/src/legacy/models/userHelpers.js
+++ b/src/legacy/models/userHelpers.js
@@ -16,7 +16,7 @@ const requiredPropertiesOnImport = ["username", "password", "firstName", "surnam
 
 const propertiesIgnoredOnImport = ["id", "created", "lastUpdated", "lastLogin"];
 
-const userCredentialsFields = ["username", "password", "userRoles", "disabled"];
+const userCredentialsFields = ["username", "password", "userRoles", "disabled", "openId"];
 
 const columnNameFromPropertyMapping = {
     id: "ID",
@@ -35,6 +35,7 @@ const columnNameFromPropertyMapping = {
     organisationUnits: "OUCapture",
     dataViewOrganisationUnits: "OUOutput",
     disabled: "Disabled",
+    openId: "Open ID",
 };
 
 const propertyFromColumnNameMapping = _.invert(columnNameFromPropertyMapping);

--- a/src/legacy/models/userList.js
+++ b/src/legacy/models/userList.js
@@ -14,7 +14,7 @@ const queryFields = [
     "lastUpdated",
     "access",
     "href",
-    "userCredentials[username,disabled,userRoles[id,displayName],lastLogin]",
+    "userCredentials[username,disabled,userRoles[id,displayName],lastLogin,openId]",
     "userGroups[id,displayName,publicAccess]",
     "organisationUnits[id,code,shortName,displayName]",
     "dataViewOrganisationUnits[id,code,shortName,displayName]",


### PR DESCRIPTION
### :pushpin: References

Task https://app.clickup.com/t/2k5g5xm

### :memo: Implementation
OpenID was missing from the query parameters for export, and didn't figured as a column or `userCredentialsFields` value for import.

For now the OpenID field must be unique for each user on import, i didn't managed to find out if this is intended or if its a quirk of the code. DHIS2 Users allows to repeat OpenIDs, but on the other hand, it looks like OpenID should map one to one to users in order to identify them.
Links: 
[OpenID Connect (OIDC) configuration](https://docs.dhis2.org/en/manage/performing-system-administration/dhis-core-version-236/installation.html#install_oidc_configuration)
[Configure OpenID Connect with Okta](https://docs.dhis2.org/en/topics/tutorials/configure-oidc-with-okta.html)