### PR TITLE
Use switch to show short names in all uses of the OrgUnitsSelector component

### DIFF
--- a/src/legacy/List/organisation-unit-dialog/OrgUnitDialog.component.js
+++ b/src/legacy/List/organisation-unit-dialog/OrgUnitDialog.component.js
@@ -124,6 +124,7 @@ class OrgUnitDialog extends React.Component {
                         filterByProgram: false,
                         selectAll: false,
                     }}
+                    showNameSetting={true}
                 />
             </ConfirmationDialog>
         );

--- a/src/webapp/components/user-form/components/OrgUnitSelectorFF.tsx
+++ b/src/webapp/components/user-form/components/OrgUnitSelectorFF.tsx
@@ -50,6 +50,7 @@ export const OrgUnitSelectorFF = ({ input, meta, validationText, ...rest }: OrgU
                     filterByProgram: false,
                     selectAll: false,
                 }}
+                showNameSetting={true}
             />
 
             {!!message && <WarningBox warning={true} title={message} />}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/2ghev8r

### :memo: Implementation

Trivial. Just added `showNameSetting={true}` to the OrgUnitsSelector component in the OrgUnitDialog component and the OrgUnitSelectorFF component.

### :art: Screenshots

When clicking on "Assign to organisation units":

![Screenshot from 2022-09-29 11-32-01](https://user-images.githubusercontent.com/1568405/192996285-0b58a7c0-b78f-49e3-9d08-2e6f24c880cd.png)


When clicking on "Assign to data view organisation units":

![Screenshot from 2022-09-29 11-32-16](https://user-images.githubusercontent.com/1568405/192996266-a4de5ca6-59a8-43bb-8821-d380336fe97e.png)


When editing a user:

![Screenshot from 2022-09-29 11-46-46](https://user-images.githubusercontent.com/1568405/192999520-a3035593-f711-4171-b1c1-6dd0b8420bee.png)

### :fire: Testing
