### PR TITLE
Comment out all uses of accountExpiry.

### DIFF
--- a/src/data/models/UserModel.ts
+++ b/src/data/models/UserModel.ts
@@ -40,7 +40,7 @@ export const UserModel: Codec<User> = Schema.object({
     ldapId: Schema.optional(Schema.string),
     externalAuth: Schema.boolean,
     password: Schema.string,
-    accountExpiry: Schema.string,
+    // accountExpiry: Schema.string,
 });
 
 export const ApiUserModel: Codec<ApiUser> = Schema.object({
@@ -76,6 +76,6 @@ export const ApiUserModel: Codec<ApiUser> = Schema.object({
         ldapId: Schema.optionalSafe(Schema.string, ""),
         externalAuth: Schema.boolean,
         password: Schema.string,
-        accountExpiry: Schema.string,
+        // accountExpiry: Schema.string,
     }),
 });

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -136,7 +136,7 @@ export class UserD2ApiRepository implements UserRepository {
                             ldapId: user?.userCredentials.ldapId,
                             externalAuth: user?.userCredentials.externalAuth,
                             password: user?.userCredentials.password,
-                            accountExpiry: user?.userCredentials.accountExpiry,
+                            // accountExpiry: user?.userCredentials.accountExpiry,
                         },
                     };
                 });
@@ -281,7 +281,7 @@ export class UserD2ApiRepository implements UserRepository {
             ldapId: userCredentials.ldapId,
             externalAuth: userCredentials.externalAuth,
             password: userCredentials.password,
-            accountExpiry: userCredentials.accountExpiry,
+            // accountExpiry: userCredentials.accountExpiry,
             authorities,
         };
     }
@@ -314,7 +314,7 @@ export class UserD2ApiRepository implements UserRepository {
                 ldapId: input.ldapId ?? "",
                 externalAuth: input.externalAuth ?? "",
                 password: input.password ?? "",
-                accountExpiry: input.accountExpiry ?? "",
+                // accountExpiry: input.accountExpiry ?? "",
             },
         };
     }
@@ -347,7 +347,7 @@ const fields = {
         ldapId: true,
         externalAuth: true,
         password: true,
-        accountExpiry: true,
+        // accountExpiry: true,
     },
 } as const;
 

--- a/src/domain/entities/User.ts
+++ b/src/domain/entities/User.ts
@@ -28,7 +28,7 @@ export interface User {
     ldapId?: string;
     externalAuth: boolean;
     password: string;
-    accountExpiry: string;
+    // accountExpiry: string;
     authorities: string[];
 }
 
@@ -59,7 +59,7 @@ export const defaultUser: User = {
     ldapId: "",
     externalAuth: false,
     password: "",
-    accountExpiry: "",
+    // accountExpiry: "",
     authorities: [""],
 };
 export interface AccessPermissions {

--- a/src/webapp/components/user-form/UserForm.tsx
+++ b/src/webapp/components/user-form/UserForm.tsx
@@ -122,8 +122,8 @@ export const RenderUserWizardField: React.FC<{ row: number; field: UserFormField
                 />
             );
         // TODO: Convert to date field
-        case "accountExpiry":
-            return <FormField {...props} component={InputFieldFF} type="datetime-local" />;
+        // case "accountExpiry":
+        //     return <FormField {...props} component={InputFieldFF} type="datetime-local" />;
         case "userGroups":
             return <FormField {...props} component={UserRoleGroupFF} modelType="userGroups" />;
         case "userRoles":

--- a/src/webapp/components/user-form/utils.ts
+++ b/src/webapp/components/user-form/utils.ts
@@ -40,8 +40,8 @@ export const getUserName = (field: UserFormField) => {
             return i18n.t("Name");
         case "password":
             return i18n.t("Password");
-        case "accountExpiry":
-            return i18n.t("Account expiration date");
+        // case "accountExpiry":
+        //     return i18n.t("Account expiration date");
         case "surname":
             return i18n.t("Surname");
         case "username":


### PR DESCRIPTION
This way, when we update a user we do not send an empty value for accountExpiry.

Dhis2 interprets now an empty value as setting it to its first date, 1970-01-01, and that stops the users from being able to connect (since the date is in the past).

### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/3jv4b34

### :memo: Implementation

Commented out all appearances of `accountExpiry`.

### :art: Screenshots

In the POST request when modifying a user, there is no `accountExpiry` anymore (and thus dhis2 doesn't set it to 1970).

![image](https://user-images.githubusercontent.com/1568405/194372837-7dd75506-def3-4dac-9a62-7eb492f42662.png)

### :fire: Testing
