### PR TITLE
include openid and password outside userCredentials

### DIFF
--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -133,6 +133,8 @@ export class UserD2ApiRepository implements UserRepository {
                         userRoles: user?.userCredentials.userRoles,
                         username: user?.userCredentials.username,
                         disabled: user?.userCredentials.disabled,
+                        openId: user?.userCredentials.openId,
+                        password: user?.userCredentials.password,
                         userCredentials: {
                             ...existingUser.userCredentials,
                             disabled: user?.userCredentials.disabled,

--- a/src/legacy/models/userHelpers.js
+++ b/src/legacy/models/userHelpers.js
@@ -18,7 +18,7 @@ const propertiesIgnoredOnImport = ["id", "created", "lastUpdated", "lastLogin"];
 
 const userCredentialsFields = ["username", "password", "userRoles", "disabled", "openId"];
 
-const user238MissingFields = ["username", "userRoles", "disabled"];
+const user238MissingFields = ["username", "userRoles", "disabled", "openId", "password"];
 
 const columnNameFromPropertyMapping = {
     id: "ID",


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/860r74hyd

### :memo: Implementation

In version 2.38.1.1 in order to update **openId** and **passwords** must be added outside **userCredentials** object.  

### :art: Screenshots

### :fire: Testing
