### PR TITLE
include user id inside userCredentials object

### DIFF
--- a/src/data/models/UserModel.ts
+++ b/src/data/models/UserModel.ts
@@ -62,6 +62,7 @@ export const ApiUserModel: Codec<ApiUser> = Schema.object({
     dataViewOrganisationUnits: Schema.array(NamedRefModel),
     access: AccessPermissionsModel,
     userCredentials: Schema.object({
+        id: Schema.string,
         username: Schema.string,
         userRoles: Schema.array(
             Schema.object({

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -314,6 +314,7 @@ export class UserD2ApiRepository implements UserRepository {
             dataViewOrganisationUnits: input.dataViewOrganisationUnits,
             access: input.access,
             userCredentials: {
+                id: input.id,
                 username: input.username,
                 userRoles: input.userRoles.map(userRole => ({ id: userRole.id, name: userRole.name, authorities: [] })),
                 lastLogin: input.lastLogin?.toISOString() ?? "",
@@ -347,6 +348,7 @@ const fields = {
     dataViewOrganisationUnits: { id: true, name: true },
     access: true,
     userCredentials: {
+        id: true,
         username: true,
         userRoles: { id: true, name: true, authorities: true },
         lastLogin: true,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865cqfvdf

### :memo: Implementation

Including user `id` inside `userCredentials` to keep compatibility with version 2.37.9.1.

Also tested on 2.36.13 and 2.38.4

### :art: Screenshots

### :fire: Testing
