### PR TITLE
avoid saving columns if value is empty

### DIFF
--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -208,7 +208,14 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     public getColumns(): FutureData<Array<keyof User>> {
-        return this.userStorage.getOrCreateObject<Array<keyof User>>(Namespaces.VISIBLE_COLUMNS, defaultColumns);
+        const $request = this.userStorage.getOrCreateObject<Array<keyof User>>(
+            Namespaces.VISIBLE_COLUMNS,
+            defaultColumns
+        );
+        return $request.flatMap(columns => {
+            const result = columns.length ? columns : defaultColumns;
+            return Future.success(result);
+        });
     }
 
     public saveColumns(columns: Array<keyof User>): FutureData<void> {

--- a/src/webapp/components/user-list-table/UserListTable.tsx
+++ b/src/webapp/components/user-list-table/UserListTable.tsx
@@ -63,8 +63,7 @@ export const UserListTable: React.FC<UserListTableProps> = ({
 
     const onReorderColumns = useCallback(
         (columns: Array<keyof User>) => {
-            if (!visibleColumns) return;
-
+            if (!visibleColumns || !columns.length) return;
             onChangeVisibleColumns(columns);
             compositionRoot.users.saveColumns(columns).run(
                 () => {},


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865bp4tzy

### :memo: Implementation

Skipping saving columns in `userDataStore` if the table components sends an empty array for columns. Showing the default columns if an empty array is found in `userDataStore` (for existing users affected by the error)

### :video_camera: Screenshots/Screen capture

### :fire: Testing

Replicating this error is very difficult, but you can simulate it by saving an empty array into the `userDataStore`

```bash
curl -u USER:PWD --location --request PUT 'http://localhost:8080/api/userDataStore/user-extended-app/visible-columns' \
--header 'Content-Type: application/json' \
--data '[]'
```

if you go to the app you will see the default columns