### PR TITLE
Show simpler 'replicate user' error message

### DIFF
--- a/src/legacy/components/ReplicateUserFromTable.component.js
+++ b/src/legacy/components/ReplicateUserFromTable.component.js
@@ -41,7 +41,12 @@ class ReplicateUserFromTable extends React.Component {
             snackActions.show({ message });
             return null;
         } else {
-            return response;
+            const errorMessage = i18n.t("Error replicating User {{user}}: {{message}}", {
+                user: userToReplicate.displayName,
+                message: response.error,
+            });
+            snackActions.show({ message: errorMessage });
+            return null;
         }
     };
 

--- a/src/legacy/components/ReplicateUserFromTable.component.js
+++ b/src/legacy/components/ReplicateUserFromTable.component.js
@@ -41,7 +41,7 @@ class ReplicateUserFromTable extends React.Component {
             snackActions.show({ message });
             return null;
         } else {
-            const errorMessage = i18n.t("Error replicating User {{user}}: {{message}}", {
+            const errorMessage = i18n.t("Error replicating user {{user}}: {{message}}", {
                 user: userToReplicate.displayName,
                 message: response.error,
             });

--- a/src/legacy/components/ReplicateUserFromTemplate.component.js
+++ b/src/legacy/components/ReplicateUserFromTemplate.component.js
@@ -133,7 +133,12 @@ class ReplicateUserFromTemplate extends React.Component {
             snackActions.show({ message });
             onRequestClose();
         } else {
-            this.setState({ infoDialog: { response } });
+            const errorMessage = i18n.t("Error replicating user {{user}}: {{message}}", {
+                user: userToReplicate.displayName,
+                message: response.error,
+            });
+            snackActions.show({ message: errorMessage });
+            onRequestClose();
         }
     };
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [[User-Extended App] - Errors when replicating users are not caught and shown, but instead, a big json file is thrown](https://app.clickup.com/t/8693ncwng)

### :memo: Implementation

- Use snackbar to show a simpler error message.

### :video_camera: Screenshots/Screen capture
<img width="1490" alt="image" src="https://github.com/EyeSeeTea/user-extended-app/assets/44171664/197fe1c4-cbe6-45e2-a04c-7063752e5a40">


### :fire: Testing
