### PR TITLE
force i18n namespace in appContext

### DIFF
--- a/i18n/es.po
+++ b/i18n/es.po
@@ -9,16 +9,16 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
 msgid "Copy to clipboard"
-msgstr ""
+msgstr "Copiar"
 
 msgid "Close"
-msgstr ""
+msgstr "Cerrar"
 
 msgid "User {{user}} replicated successfully {{n}} times"
-msgstr ""
+msgstr "Usuario {{user}} replicado correctamente {{n}} veces"
 
 msgid "Error replicating user {{user}}: {{message}}"
-msgstr ""
+msgstr "Error replicando usuario {{user}}: {{message}}"
 
 msgid "Replicate {{user}}"
 msgstr "Replicar {{user}}"
@@ -27,94 +27,94 @@ msgid "Replicate"
 msgstr "Replicar"
 
 msgid "Value should be between {{min}} and {{max}}"
-msgstr ""
+msgstr "El valor debe estar entre {{min}} y {{max}}"
 
 msgid "Username. Example for two users: admin.$index -> admin.1, admin.2"
-msgstr ""
+msgstr "Ejemplo para dos usuarios: admin.$index -> admin.1, admin.2"
 
 msgid "Replicate error"
 msgstr "Replicar error"
 
 msgid "Settings"
-msgstr ""
+msgstr "Configuración"
 
 msgid "Columns to show in table"
-msgstr ""
+msgstr "Columnas a mostrar en tabla"
 
 msgid "Column"
-msgstr ""
+msgstr "Columna"
 
 msgid "Type"
 msgstr ""
 
 msgid "Created"
-msgstr ""
+msgstr "Creado"
 
 msgid "Updated"
-msgstr ""
+msgstr "Actualizado"
 
 msgid "Deleted"
-msgstr ""
+msgstr "Eliminado"
 
 msgid "Ignored"
-msgstr ""
+msgstr "Ignorado"
 
 msgid "Total"
 msgstr ""
 
 msgid "Identifier"
-msgstr ""
+msgstr "Identificador"
 
 msgid "Message"
-msgstr ""
+msgstr "Mensaje"
 
 msgid "Import Results"
-msgstr ""
+msgstr "Resultados de la importación"
 
 msgid "Ok"
 msgstr ""
 
 msgid "Users"
-msgstr ""
+msgstr "Usuarios"
 
 msgid "Import"
-msgstr ""
+msgstr "Importar"
 
 msgid "Status"
-msgstr ""
+msgstr "Estado"
 
 msgid "Summary"
-msgstr ""
+msgstr "Resumen"
 
 msgid "Messages"
-msgstr ""
+msgstr "Mensajes"
 
 msgid "JSON Response"
-msgstr ""
+msgstr "Respuesta en JSON"
 
 msgid "Saving users"
-msgstr ""
+msgstr "Guardando usuarios"
 
 msgid "Update strategy: "
-msgstr ""
+msgstr "Estrategia de actualización: "
 
 msgid "Merge"
-msgstr ""
+msgstr "Mezclar"
 
 msgid "Replace"
-msgstr ""
+msgstr "Reemplazar"
 
 msgid "Search"
-msgstr ""
+msgstr "Buscar"
 
 msgid "Assign roles to {{usernames}}"
-msgstr ""
+msgstr "Asignar roles a {{usernames}}"
 
 msgid "Assign groups to {{usernames}}"
-msgstr ""
+msgstr "Asignar grupos a {{usernames}}"
 
 msgid "Bulk update strategy: {{strategy}}"
-msgstr ""
+msgstr "Estrategia de actualización masiva: {{strategy}}"
 
 msgid "Back"
 msgstr "Volver"
@@ -123,70 +123,72 @@ msgid "Help"
 msgstr "Ayuda"
 
 msgid "General info"
-msgstr ""
+msgstr "Información General"
 
 msgid "Assignment"
 msgstr ""
 
 msgid "Other information"
-msgstr ""
+msgstr "Otra información"
 
 msgid "Error saving user"
-msgstr ""
+msgstr "Error al guardar usuario"
 
 msgid "Save"
-msgstr ""
+msgstr "Guardar"
 
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 msgid "Please provide a valid identifier"
-msgstr ""
+msgstr "Por favor proporcione un identificador válido"
 
 msgid "Please provide a valid email"
-msgstr ""
+msgstr "Por favor proporcione un correo electrónico válido"
 
 msgid "Password should contain at least one lowercase letter"
-msgstr ""
+msgstr "La contraseña debe contener al menos una letra minúscula"
 
 msgid "Password should contain at least one UPPERCASE letter"
-msgstr ""
+msgstr "La contraseña debe contener al menos una letra MAYÚSCULA"
 
 msgid "Password should contain at least one number"
-msgstr ""
+msgstr "La contraseña debe contener al menos un número"
 
 msgid "Password should have at least one special character"
-msgstr ""
+msgstr "La contraseña debe contener al menos un carácter especial"
 
 msgid "Please provide a valid phone number"
-msgstr ""
+msgstr "Por favor proporcione un número de teléfono válido"
 
 msgid "Please provide a valid international phone number (+0123456789)"
 msgstr ""
+"Por favor proporcione un número de teléfono internacional válido "
+"(+0123456789)"
 
 msgid "First Name"
-msgstr ""
+msgstr "Nombre"
 
 msgid "Name"
-msgstr ""
+msgstr "Nombre"
 
 msgid "Password"
-msgstr ""
+msgstr "Contraseña"
 
 msgid "Account expiration date"
-msgstr ""
+msgstr "Fecha de expiración de la cuenta"
 
 msgid "Surname"
-msgstr ""
+msgstr "Apellido"
 
 msgid "Username"
-msgstr ""
+msgstr "Usuario"
 
 msgid "Email"
-msgstr ""
+msgstr "Correo electrónico"
 
 msgid "Phone Number"
-msgstr ""
+msgstr "Número de teléfono"
 
 msgid "WhatsApp"
 msgstr ""
@@ -204,46 +206,47 @@ msgid "Twitter"
 msgstr ""
 
 msgid "Disabled"
-msgstr ""
+msgstr "Deshabilitado"
 
 msgid "External authentication only (OpenID or LDAP)"
-msgstr ""
+msgstr "Solo autenticación externa (OpenID o LDAP)"
 
 msgid "User Roles"
-msgstr ""
+msgstr "Roles"
 
 msgid "User Groups"
-msgstr ""
+msgstr "Grupos"
 
+#, fuzzy
 msgid "Data Capture Organisation Units"
-msgstr ""
+msgstr "Unidades Organizativas de salida"
 
 msgid "Data View Organisation Units"
-msgstr ""
+msgstr "Unidades Organizativas de salida"
 
 msgid "Search Organisation Units"
-msgstr ""
+msgstr "Unidades Organizativas de búsqueda"
 
 msgid "Open ID"
 msgstr ""
 
 msgid "LDAP identifier"
-msgstr ""
+msgstr "LDAP ID"
 
 msgid "Interface language"
-msgstr ""
+msgstr "Idioma de la interfaz"
 
 msgid "Database language"
-msgstr ""
+msgstr "Idioma de la base de datos"
 
 msgid "Api URL"
 msgstr ""
 
 msgid "Last updated"
-msgstr ""
+msgstr "Última actualización"
 
 msgid "Last login"
-msgstr ""
+msgstr "Última conexión"
 
 msgid "ID"
 msgstr ""
@@ -252,10 +255,10 @@ msgid "API URL"
 msgstr ""
 
 msgid "Roles"
-msgstr ""
+msgstr "Roles"
 
 msgid "Groups"
-msgstr ""
+msgstr "Grupos"
 
 msgid "OU Capture"
 msgstr ""
@@ -270,99 +273,103 @@ msgid "Details"
 msgstr "Detalles"
 
 msgid "Edit"
-msgstr ""
+msgstr "Editar"
 
 msgid "Copy in user"
-msgstr ""
+msgstr "Copiar a usuario"
 
+#, fuzzy
 msgid "Assign to data capture organisation units"
-msgstr ""
+msgstr "Asignar a unidades organizativas de salida"
 
 msgid "Assign to data view organisation units"
-msgstr ""
+msgstr "Asignar a unidades organizativas de salida"
 
 msgid "Assign to search organisation units"
-msgstr ""
+msgstr "Asignar a unidades organizativas de búsqueda"
 
 msgid "Assign roles"
-msgstr ""
+msgstr "Asignar roles"
 
 msgid "Assign groups"
-msgstr ""
+msgstr "Asignar grupos"
 
 msgid "Enable"
-msgstr ""
+msgstr "Habilitar"
 
 msgid "Disable"
-msgstr ""
+msgstr "Deshabilitar"
 
 msgid "Remove"
-msgstr ""
+msgstr "Eliminar"
 
 msgid "Replicate user from template"
-msgstr ""
+msgstr "Replicar usuario desde plantilla"
 
 msgid "Replicate user from table"
-msgstr ""
+msgstr "Replicar usuario desde tabla"
 
 msgid "Search by name or username..."
-msgstr ""
+msgstr "Buscar por nombre y nombre de usuario"
 
 msgid "Assign to organisation units capture"
-msgstr ""
+msgstr "Asignar a unidades organizativas"
 
 msgid "Assign to organisation units output"
-msgstr ""
+msgstr "Asignar a unidades organizativas de salida"
 
 msgid "Assign to organisation units search"
-msgstr ""
+msgstr "Asignar a unidades organizativas de búsqueda"
 
 msgid "{{action}}: {{users}} {{remainingCount}}"
 msgstr ""
 
 msgid "User ID"
-msgstr ""
+msgstr "ID"
 
 msgid "First name"
-msgstr ""
+msgstr "Nombre"
 
 msgid "Phone number"
-msgstr ""
+msgstr "Número de teléfono móvil"
 
+#, fuzzy
 msgid "Data capture organisation units"
-msgstr ""
+msgstr "Unidades organizativas de salida"
 
 msgid "Data view organisation units"
-msgstr ""
+msgstr "Unidades organizativas de salida"
 
 msgid "Search organisation units"
-msgstr ""
+msgstr "Unidades organizativas de búsqueda"
 
 msgid "Created By"
-msgstr ""
+msgstr "Creado por"
 
 msgid "Last Modified By"
-msgstr ""
+msgstr "Última actualización hecha por"
 
 msgid "And {{overflow}} more..."
-msgstr ""
+msgstr "Y {{overflow}} más..."
 
 msgid "Users {{action}}. {{users}} {{remainingCount}}"
-msgstr ""
+msgstr "Usuarios {{action}}. {{users}} {{remainingCount}}"
 
 msgid "{{action}} users"
-msgstr ""
+msgstr "{{action}} usuarios"
 
 msgid ""
 "Are you sure you want to {{action}} the selected users? {{users}} "
 "{{remainingCount}}"
 msgstr ""
+"¿Estás seguro de que deseas {{action}} los usuarios seleccionados? {{users}} "
+"{{remainingCount}}"
 
 msgid "Confirm"
-msgstr ""
+msgstr "Confirmar"
 
 msgid "Saving..."
-msgstr ""
+msgstr "Guardando..."
 
 msgid "Distributed under GNU GLPv3"
 msgstr ""
@@ -389,7 +396,7 @@ msgid ""
 msgstr ""
 
 msgid "About User Extended App"
-msgstr ""
+msgstr "Sobre User Extended"
 
 msgid "Samaritan's Purse"
 msgstr ""
@@ -407,34 +414,43 @@ msgid "MSF"
 msgstr ""
 
 msgid "Edit users"
-msgstr ""
+msgstr "Editar usuarios"
 
 msgid "Column settings"
-msgstr ""
+msgstr "Gestionar columnas"
 
 msgid "Error saving users"
-msgstr ""
+msgstr "Error al guardar usuarios"
 
 msgid "Add user"
-msgstr ""
+msgstr "Agregar usuario"
 
 msgid "Delete"
-msgstr ""
+msgstr "Eliminar Delete"
 
 msgid "Edit user"
-msgstr ""
+msgstr "Editar usuario"
 
 msgid "New user"
 msgstr "Nuevo usuario"
 
 msgid "Network error"
-msgstr ""
+msgstr "Error de red"
 
 msgid "Unable to load user {{id}}"
-msgstr ""
+msgstr "Error al obtener el usuario {{id}}"
 
 msgid "Open in user management"
-msgstr ""
+msgstr "Abrir en Administración de usuarios"
 
 msgid " and {{overflow}} more..."
-msgstr ""
+msgstr " y {{overflow}} más..."
+
+#~ msgid "Organisation Units"
+#~ msgstr "Unidades Organizativas"
+
+#~ msgid "Assign to organisation units"
+#~ msgstr "Asignar a unidades organizativas"
+
+#~ msgid "Organisation units"
+#~ msgstr "Unidades organizativas"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -445,12 +445,3 @@ msgstr "Abrir en Administración de usuarios"
 
 msgid " and {{overflow}} more..."
 msgstr " y {{overflow}} más..."
-
-#~ msgid "Organisation Units"
-#~ msgstr "Unidades Organizativas"
-
-#~ msgid "Assign to organisation units"
-#~ msgstr "Asignar a unidades organizativas"
-
-#~ msgid "Organisation units"
-#~ msgstr "Unidades organizativas"

--- a/src/types/i18n.d.ts
+++ b/src/types/i18n.d.ts
@@ -1,4 +1,5 @@
 declare module "@dhis2/d2-i18n" {
     export function t(value: string, namespace?: object): string;
     export function changeLanguage(locale: string);
+    export function setDefaultNamespace(namespace: string);
 }

--- a/src/webapp/components/user-list-table/UserListTable.tsx
+++ b/src/webapp/components/user-list-table/UserListTable.tsx
@@ -100,6 +100,7 @@ export const UserListTable: React.FC<UserListTableProps> = ({
     const enableReplicate = hasReplicateAuthority(currentUser);
     const snackbar = useSnackbar();
     const navigate = useNavigate();
+    const userColumns = useUserColumns();
 
     const { users, setUsers } = useGetUsersByIds(selectedUserIds);
 
@@ -144,7 +145,7 @@ export const UserListTable: React.FC<UserListTableProps> = ({
 
     const baseConfig = useMemo((): TableConfig<User> => {
         return {
-            columns,
+            columns: userColumns,
             details: [
                 { name: "name", text: i18n.t("Name") },
                 { name: "username", text: i18n.t("Username") },
@@ -327,7 +328,7 @@ export const UserListTable: React.FC<UserListTableProps> = ({
             // onActionButtonClick: () => navigate("/new"),
             onReorderColumns,
         };
-    }, [openSettings, enableReplicate, editUsers, onReorderColumns, reload, onAction]);
+    }, [openSettings, enableReplicate, editUsers, onReorderColumns, reload, onAction, userColumns]);
 
     const refreshRows = useCallback(
         async (
@@ -472,74 +473,79 @@ export const UserListTable: React.FC<UserListTableProps> = ({
     );
 };
 
-export const columns: TableColumn<User>[] = [
-    { name: "id", sortable: false, text: i18n.t("User ID"), hidden: true },
-    { name: "username", sortable: false, text: i18n.t("Username") },
-    { name: "firstName", sortable: true, text: i18n.t("First name") },
-    { name: "surname", sortable: true, text: i18n.t("Surname") },
-    { name: "email", sortable: true, text: i18n.t("Email") },
-    { name: "phoneNumber", text: i18n.t("Phone number") },
-    { name: "openId", sortable: false, text: i18n.t("Open ID"), hidden: true },
-    { name: "created", sortable: true, text: i18n.t("Created"), hidden: true },
-    { name: "lastUpdated", sortable: true, text: i18n.t("Last updated"), hidden: true },
-    { name: "apiUrl", sortable: false, text: i18n.t("API URL"), hidden: true },
-    {
-        name: "userRoles",
-        sortable: false,
-        text: i18n.t("Roles"),
-        getValue: user => buildEllipsizedList(user.userRoles),
-        hidden: true,
-    },
-    {
-        name: "userGroups",
-        sortable: false,
-        text: i18n.t("Groups"),
-        getValue: user => buildEllipsizedList(user.userGroups),
-        hidden: true,
-    },
-    {
-        name: "organisationUnits",
-        sortable: false,
-        text: i18n.t("Data capture organisation units"),
-        getValue: user => buildEllipsizedList(user.organisationUnits),
-    },
-    {
-        name: "dataViewOrganisationUnits",
-        sortable: false,
-        text: i18n.t("Data view organisation units"),
-        getValue: user => buildEllipsizedList(user.dataViewOrganisationUnits),
-    },
-    {
-        name: "searchOrganisationsUnits",
-        sortable: false,
-        text: i18n.t("Search organisation units"),
-        getValue: user => buildEllipsizedList(user.searchOrganisationsUnits),
-    },
-    { name: "lastLogin", sortable: false, text: i18n.t("Last login") },
-    {
-        name: "status",
-        sortable: true,
-        text: i18n.t("Status"),
-    },
-    {
-        name: "disabled",
-        sortable: false,
-        text: i18n.t("Disabled"),
-        getValue: row => (row.disabled ? <Check /> : undefined),
-    },
-    {
-        name: "createdBy",
-        sortable: false,
-        text: i18n.t("Created By"),
-        getValue: row => row.createdBy?.username || "",
-    },
-    {
-        name: "lastModifiedBy",
-        sortable: false,
-        text: i18n.t("Last Modified By"),
-        getValue: row => row.lastModifiedBy?.username || "",
-    },
-];
+function useUserColumns() {
+    const columns = React.useMemo((): TableColumn<User>[] => {
+        return [
+            { name: "id", sortable: false, text: i18n.t("User ID"), hidden: true },
+            { name: "username", sortable: false, text: i18n.t("Username") },
+            { name: "firstName", sortable: true, text: i18n.t("First name") },
+            { name: "surname", sortable: true, text: i18n.t("Surname") },
+            { name: "email", sortable: true, text: i18n.t("Email") },
+            { name: "phoneNumber", text: i18n.t("Phone number") },
+            { name: "openId", sortable: false, text: i18n.t("Open ID"), hidden: true },
+            { name: "created", sortable: true, text: i18n.t("Created"), hidden: true },
+            { name: "lastUpdated", sortable: true, text: i18n.t("Last updated"), hidden: true },
+            { name: "apiUrl", sortable: false, text: i18n.t("API URL"), hidden: true },
+            {
+                name: "userRoles",
+                sortable: false,
+                text: i18n.t("Roles"),
+                getValue: user => buildEllipsizedList(user.userRoles),
+                hidden: true,
+            },
+            {
+                name: "userGroups",
+                sortable: false,
+                text: i18n.t("Groups"),
+                getValue: user => buildEllipsizedList(user.userGroups),
+                hidden: true,
+            },
+            {
+                name: "organisationUnits",
+                sortable: false,
+                text: i18n.t("Data capture organisation units"),
+                getValue: user => buildEllipsizedList(user.organisationUnits),
+            },
+            {
+                name: "dataViewOrganisationUnits",
+                sortable: false,
+                text: i18n.t("Data view organisation units"),
+                getValue: user => buildEllipsizedList(user.dataViewOrganisationUnits),
+            },
+            {
+                name: "searchOrganisationsUnits",
+                sortable: false,
+                text: i18n.t("Search organisation units"),
+                getValue: user => buildEllipsizedList(user.searchOrganisationsUnits),
+            },
+            { name: "lastLogin", sortable: false, text: i18n.t("Last login") },
+            {
+                name: "status",
+                sortable: true,
+                text: i18n.t("Status"),
+            },
+            {
+                name: "disabled",
+                sortable: false,
+                text: i18n.t("Disabled"),
+                getValue: row => (row.disabled ? <Check /> : undefined),
+            },
+            {
+                name: "createdBy",
+                sortable: false,
+                text: i18n.t("Created By"),
+                getValue: row => row.createdBy?.username || "",
+            },
+            {
+                name: "lastModifiedBy",
+                sortable: false,
+                text: i18n.t("Last Modified By"),
+                getValue: row => row.lastModifiedBy?.username || "",
+            },
+        ];
+    }, []);
+    return columns;
+}
 
 function checkAccess(requiredKeys: string[]) {
     return (users: User[]) =>

--- a/src/webapp/contexts/app-context.ts
+++ b/src/webapp/contexts/app-context.ts
@@ -2,6 +2,7 @@ import React, { useContext } from "react";
 import { CompositionRoot } from "../../CompositionRoot";
 import { User } from "../../domain/entities/User";
 import { D2Api } from "../../types/d2-api";
+import i18n from "./../../locales";
 
 export interface AppContextState {
     api: D2Api;
@@ -13,6 +14,7 @@ export interface AppContextState {
 export const AppContext = React.createContext<AppContextState | null>(null);
 
 export function useAppContext() {
+    i18n.setDefaultNamespace("user-extended-app");
     const context = useContext(AppContext);
     if (context) {
         return context;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/86944c81y

### :memo: Implementation

Feedback component was overriding the namespace translation. This PR is forcing to use the app namespace. At the beginning I though we needed [an update of feedback-component](https://github.com/EyeSeeTea/feedback-component/pull/4), but it's not really necessary.

### :video_camera: Screenshots/Screen capture

Spanish translations
![image](https://github.com/EyeSeeTea/user-extended-app/assets/461124/0d4d9b28-19fb-449f-b46e-fb608adf929c)

### :fire: Testing

- Go to user settings http://localhost:8080/dhis-web-user-profile/#/settings
- Change interface language to spanish
- Test


86944c81y