### PR TITLE
chore: add CI workflow on push (localize, jest, tsc)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,47 @@
+name: Application testing
+on:
+    push:
+    workflow_dispatch:
+jobs:
+    unit-tests:
+        name: Unit tests
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Install apt libraries
+              run: sudo apt install gettext -y
+
+            - name: Setup Node
+              uses: actions/setup-node@v1
+              with:
+                  node-version: "12.x"
+
+            - name: Install yarn
+              run: npm install -g yarn
+
+            - name: Get yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+
+            - name: Cache yarn dependencies
+              uses: actions/cache@v2
+              id: yarn-cache
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
+
+            - name: Install dependencies
+              run: yarn install --frozen-lockfile --silent
+
+            - name: Install translations
+              run: yarn localize
+
+            - name: Run jest tests
+              run: yarn test
+
+            - name: Run typescript tests
+              run: npx tsc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v1
               with:
-                  node-version: "12.x"
+                  node-version: "16.14.0"
 
             - name: Install yarn
               run: npm install -g yarn

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="react-scripts" />
+declare module "*.png";
+declare module "*.svg";
+declare module "*.jpeg";
+declare module "*.jpg";


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** https://app.clickup.com/t/8694ekvck
- 8694ekvck

### :memo: Implementation
Since we add unit tests it could be nice to fire them when we push.

### :fire: Testing
You can use [act](https://nektosact.com/introduction.html) to test it locally with `act -n`