### PR TITLE
include timestamp to url to avoid cache

### DIFF
--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -163,6 +163,7 @@ export class UserD2ApiRepository implements UserRepository {
                             userCredentials: { ...fields.userCredentials, ...auditFields },
                         },
                         filter: { id: { in: usersIds } },
+                        v: +new Date().getTime(),
                     })
                 ).flatMap(({ objects }) => {
                     const users = objects.map(user => this.toDomainUser(user));
@@ -194,6 +195,7 @@ export class UserD2ApiRepository implements UserRepository {
                     ...otherFilters,
                 },
                 order: `${sorting.field}:${sorting.order}`,
+                v: +new Date().getTime(),
             })
         );
         return userData$.map(({ objects }) => objects);

--- a/src/legacy/models/userHelpers.js
+++ b/src/legacy/models/userHelpers.js
@@ -444,6 +444,7 @@ async function getExistingUsers(d2, options = {}) {
         paging: false,
         fields: options.fields || "id,userCredentials[username]",
         ...options,
+        v: +new Date().getTime(),
     });
     return users;
 }

--- a/src/webapp/hooks/userHooks.ts
+++ b/src/webapp/hooks/userHooks.ts
@@ -9,7 +9,6 @@ import i18n from "../../locales";
 import { AllowedExportFormat, ColumnMappingKeys } from "../../domain/usecases/ExportUsersUseCase";
 import FileSaver from "file-saver";
 import { OrgUnitKey } from "../../domain/entities/OrgUnit";
-import { Maybe } from "../../types/utils";
 
 type UseSaveUsersOrgUnitsProps = { onSuccess: () => void };
 type UseExportUsersProps = {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694vdgyw

### :memo: Implementation

- [x] add a "v" (short for version) parameter to the users endpoint to avoid dhis2 cache. The value will be a timestamp.

### :video_camera: Screenshots/Screen capture

![image](https://github.com/EyeSeeTea/user-extended-app/assets/461124/e8ab2465-1f4a-4af2-8597-4503c5929ab4)

### :fire: Testing

Select any user and edit roles from the `Edit page` or the `Assign roles` action from the table.

#8694vdgyw