### PR TITLE
saving user groups using the collection endpoint instead metadata

### DIFF
--- a/src/legacy/List/List.component.js
+++ b/src/legacy/List/List.component.js
@@ -199,7 +199,7 @@ export class ListHybrid extends React.Component {
     };
 
     _importUsers = async users => {
-        const response = await saveUsers(this.context.d2, users);
+        const response = await saveUsers(this.context.d2, users, this.props.api);
         if (response.success) {
             const message = this.getTranslation("import_successful", { n: users.length });
             snackActions.show({ message });


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694um027

### :memo: Implementation

- [x] Getting users groups from /api/usersGroups instead /api/users
- [x] Saving user groups using the [collection object endpoint](https://docs.dhis2.org/en/full/develop/dhis-core-version-238/developer-manual.html#webapi_adding_removing_objects_collections) instead metadata.

### :video_camera: Screenshots/Screen capture

### :fire: Testing
