### PR TITLE
Fix: CSV import fails in DHIS2.37 due to missing userCredentials.

### DIFF
--- a/src/legacy/models/userHelpers.js
+++ b/src/legacy/models/userHelpers.js
@@ -12,7 +12,8 @@ const fieldSplitChar = "||";
 
 export const fieldImportSuffix = "Import";
 
-const requiredPropertiesOnImport = ["username", "password", "firstName", "surname", "userRoles"];
+// NOTE: UEApp allows to create a user without organisationUnits, but DHIS2 User App does not.
+const requiredPropertiesOnImport = ["username", "password", "firstName", "surname", "userRoles", "organisationUnits"];
 
 const propertiesIgnoredOnImport = ["id", "created", "lastUpdated", "lastLogin"];
 
@@ -404,6 +405,7 @@ async function saveUsers(d2, users, d2Api, currentUser) {
     const d2Logger = await buildLogger(d2Api, currentUser);
     d2Logger?.log({ users: buildUserWithoutPassword(users) });
     const response = await postMetadata(api, { users: users }, d2Logger);
+    // NOTE: this executes even when postMetadata fails
     await userRepository.updateUserGroups(usersToSave, existingUsersToUpdate, d2Logger).runAsync();
     return response;
 }

--- a/src/legacy/models/userHelpers.js
+++ b/src/legacy/models/userHelpers.js
@@ -404,7 +404,7 @@ async function saveUsers(d2, users, d2Api, currentUser) {
     const usersToSave = getUsersToSave(users, existingUsersToUpdate);
     const d2Logger = await buildLogger(d2Api, currentUser);
     d2Logger?.log({ users: buildUserWithoutPassword(users) });
-    const response = await postMetadata(api, { users: users }, d2Logger);
+    const response = await postMetadata(api, { users: usersToSave }, d2Logger);
     // NOTE: this executes even when postMetadata fails
     await userRepository.updateUserGroups(usersToSave, existingUsersToUpdate, d2Logger).runAsync();
     return response;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [[User feedback] Cannot update users from CSV](https://app.clickup.com/t/8695ujvwy)

### :memo: Implementation

In DHIS 2.37 the API POST to `api/metadata` fails because the provided user objects lack the `userCredentials` property.
This issue doesn't happen in DHIS2.38.

The proposed solution until this feature gets refactored is to use the `usersToSave` variable as the payload.
This variable contains the user metadata merged with the import changes in case of overwrite and a minimal user object in case of creating a new one.


####  Less urgent issues:
In the debugging process the following bugs were identified:
- Capture OrgUnits was not a mandatory field in the import table, it is in the User App. It was added as a required property.
- The import process allows creating users without roles or Capture OrgUnits. There is a [import table migration PR](https://github.com/EyeSeeTea/user-extended-app/pull/295), not sure if fixed there.
- If a `api/metadata` POST fails the calls to modify the `userGroups` from `userRepository.updateUserGroups` are still made.
![image](https://github.com/user-attachments/assets/bc5bda91-778f-4517-b4f5-20ae9dcf0d81)
- `updateUserGroups` fails if a user without userGroups is imported, admittedly this a rare corner case.


### :video_camera: Screenshots/Screen capture

### :fire: Testing
