### PR TITLE
Fix: CSV import removes existing userGroups memberships

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-10-10T02:03:30.660Z\n"
-"PO-Revision-Date: 2024-10-10T02:03:30.660Z\n"
+"POT-Creation-Date: 2024-10-21T20:07:31.924Z\n"
+"PO-Revision-Date: 2024-10-21T20:07:31.924Z\n"
 
 msgid "ID"
 msgstr ""
@@ -191,10 +191,19 @@ msgstr ""
 msgid "Remove user"
 msgstr ""
 
+msgid "Duplicated username: {{username}}"
+msgstr ""
+
+msgid "Please provide a username"
+msgstr ""
+
 msgid "User already exists"
 msgstr ""
 
 msgid "Please provide a valid email"
+msgstr ""
+
+msgid "Please provide a password"
 msgstr ""
 
 msgid "Password should contain at least one lowercase letter"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-10-10T01:46:23.785Z\n"
+"POT-Creation-Date: 2024-10-21T20:05:12.594Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -195,11 +195,20 @@ msgstr ""
 msgid "Remove user"
 msgstr "Eliminar usuario"
 
+msgid "Duplicated username: {{username}}"
+msgstr "Usuario duplicado: {{user}}"
+
+msgid "Please provide a username"
+msgstr "Por favor proporcione un nombre de usuario"
+
 msgid "User already exists"
 msgstr ""
 
 msgid "Please provide a valid email"
 msgstr "Por favor proporcione un correo electrónico válido"
+
+msgid "Please provide a password"
+msgstr "Por favor proporcione una contraseña"
 
 msgid "Password should contain at least one lowercase letter"
 msgstr "La contraseña debe contener al menos una letra minúscula"

--- a/src/data/models/DHIS2Model.ts
+++ b/src/data/models/DHIS2Model.ts
@@ -14,7 +14,7 @@ export const NamedRefModel: Codec<NamedRef> = Schema.object({
 export const OrgUnitModel = Schema.object({
     id: Schema.string,
     name: Schema.string,
-    code: Schema.string,
+    code: Schema.optionalSafe(Schema.string, ""),
     path: Schema.string,
 });
 

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -589,7 +589,19 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     private getApiOrgUnits(orgUnits: OrgUnit[]): ApiD2OrgUnit[] {
-        return orgUnits.map(orgUnit => ({ ...orgUnit, path: joinPaths(orgUnit) }));
+        const tmp = _.compact(
+            orgUnits.map(orgUnit => {
+                if (orgUnit.id === "") {
+                    return undefined;
+                }
+                return {
+                    ...orgUnit,
+                    path: joinPaths(orgUnit),
+                };
+            })
+        );
+        console.debug("getApiOrgUnits", orgUnits, tmp);
+        return tmp;
     }
 }
 

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -589,7 +589,7 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     private getApiOrgUnits(orgUnits: OrgUnit[]): ApiD2OrgUnit[] {
-        const tmp = _.compact(
+        return _.compact(
             orgUnits.map(orgUnit => {
                 if (orgUnit.id === "") {
                     return undefined;
@@ -600,8 +600,6 @@ export class UserD2ApiRepository implements UserRepository {
                 };
             })
         );
-        console.debug("getApiOrgUnits", orgUnits, tmp);
-        return tmp;
     }
 }
 

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -591,13 +591,7 @@ export class UserD2ApiRepository implements UserRepository {
     private getApiOrgUnits(orgUnits: OrgUnit[]): ApiD2OrgUnit[] {
         return _.compact(
             orgUnits.map(orgUnit => {
-                if (orgUnit.id === "") {
-                    return undefined;
-                }
-                return {
-                    ...orgUnit,
-                    path: joinPaths(orgUnit),
-                };
+                return orgUnit.id === "" ? undefined : { ...orgUnit, path: joinPaths(orgUnit) };
             })
         );
     }

--- a/src/domain/usecases/ImportUsersUseCase.ts
+++ b/src/domain/usecases/ImportUsersUseCase.ts
@@ -39,6 +39,10 @@ export class ImportUsersUseCase implements UseCase {
             const hasRequiredFields = UserLogic.validateHasRequiredFields(users);
             if (!hasRequiredFields)
                 return Future.error("All users must have at least one Organisation Unit, Role and Group");
+
+            const hasDuplicatedUsernames = _.uniq(usernameList).length !== usernameList.length;
+            if (hasDuplicatedUsernames) return Future.error("Usernames must be unique");
+
             const mergedUsers = this.mergeUsers(users, usersFromDB, currentUser);
             return this.saveUsers(mergedUsers);
         });

--- a/src/legacy/models/userHelpers.js
+++ b/src/legacy/models/userHelpers.js
@@ -12,8 +12,16 @@ const fieldSplitChar = "||";
 
 export const fieldImportSuffix = "Import";
 
-// NOTE: UEApp allows to create a user without organisationUnits, but DHIS2 User App does not.
-const requiredPropertiesOnImport = ["username", "password", "firstName", "surname", "userRoles", "organisationUnits"];
+// NOTE: userGroups is not a required property, but the app will not work without it
+const requiredPropertiesOnImport = [
+    "username",
+    "password",
+    "firstName",
+    "surname",
+    "userRoles",
+    "userGroups",
+    "organisationUnits",
+];
 
 const propertiesIgnoredOnImport = ["id", "created", "lastUpdated", "lastLogin"];
 

--- a/src/webapp/components/form/fields/TransferFF.tsx
+++ b/src/webapp/components/form/fields/TransferFF.tsx
@@ -25,7 +25,7 @@ export const TransferFF = ({
 }: TransferFFProps) => {
     const isLoading = loading || (showLoadingStatus && meta.validating);
     const message = validationText ?? meta.error ?? meta.submitError;
-    const selected = input.value.map(({ id }: NamedRef) => id);
+    const selected = Array.isArray(input.value) ? input.value.map(({ id }: NamedRef) => id) : [];
 
     const onChange = useCallback(
         ({ selected }: { selected: string[] }) => {

--- a/src/webapp/components/import-export/ImportTable.tsx
+++ b/src/webapp/components/import-export/ImportTable.tsx
@@ -307,7 +307,7 @@ export const ImportTable: React.FC<ImportTableProps> = props => {
                                 autocomplete="off"
                                 onSubmit={onSubmit}
                                 initialValues={{ users }}
-                                render={({ handleSubmit, values }) => {
+                                render={({ handleSubmit, form, values }) => {
                                     const canAddNewUser = values.users.length < ImportUser.MAX_USERS;
                                     return (
                                         <>

--- a/src/webapp/components/import-export/ImportTable.tsx
+++ b/src/webapp/components/import-export/ImportTable.tsx
@@ -168,7 +168,10 @@ export const ImportTable: React.FC<ImportTableProps> = props => {
     };
 
     const toggleAllowOverwrite = useCallback(
-        (_event, newValue: boolean) => {
+        (_event, newValue: boolean, form) => {
+            requestAnimationFrame(() => {
+                form.change("updateValidation", newValue);
+            });
             setAreUsersValid(newValue || !errorsCount);
             setAllowOverwrite(newValue);
         },
@@ -344,17 +347,24 @@ export const ImportTable: React.FC<ImportTableProps> = props => {
                                                     />
                                                 </AddButtonRow>
                                             </form>
+                                            {showOverwriteToggle && !templateUser && (
+                                                <FormControlLabel
+                                                    control={
+                                                        <Switch
+                                                            checked={allowOverwrite}
+                                                            onChange={(event, newValue) =>
+                                                                toggleAllowOverwrite(event, newValue, form)
+                                                            }
+                                                        />
+                                                    }
+                                                    label={i18n.t("Overwrite existing users")}
+                                                />
+                                            )}
                                         </>
                                     );
                                 }}
                             />
                         </TableContainer>
-                        {showOverwriteToggle && !templateUser && (
-                            <FormControlLabel
-                                control={<Switch checked={allowOverwrite} onChange={toggleAllowOverwrite} />}
-                                label={i18n.t("Overwrite existing users")}
-                            />
-                        )}
                     </div>
                 )}
             </DialogContent>

--- a/src/webapp/components/import-export/ImportTable.tsx
+++ b/src/webapp/components/import-export/ImportTable.tsx
@@ -565,8 +565,18 @@ const useValidations = (
                 validation: (value: string) => {
                     if (allowOverwrite) return "";
                     if (!value) return i18n.t("Please provide a username");
-                    const errorMessage = !existingUsersNames.includes(value) ? "" : i18n.t("User already exists");
-                    return errorMessage;
+                    const existingUser = existingUsersNames.includes(value);
+                    if (allowOverwrite && existingUser) return "";
+                    if (existingUser) {
+                        return i18n.t("User already exists");
+                    } else {
+                        const validators = composeValidators(
+                            string,
+                            createMinCharacterLength(2),
+                            createMaxCharacterLength(140)
+                        );
+                        return validators(value);
+                    }
                 },
             };
         }

--- a/src/webapp/components/user-form/components/OrgUnitSelectorFF.tsx
+++ b/src/webapp/components/user-form/components/OrgUnitSelectorFF.tsx
@@ -49,7 +49,7 @@ export const OrgUnitSelectorFF = ({ input, meta, validationText, ...rest }: OrgU
     );
 
     React.useEffect(() => {
-        const ids = input.value.map(({ id }: NamedRef) => id);
+        const ids = Array.isArray(input.value) ? input.value.map(({ id }: NamedRef) => id) : [];
         return compositionRoot.metadata.getOrgUnitPaths(ids).run(
             items => {
                 setSelectedPaths(items.map(orgUnit => joinPaths(orgUnit)));


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [[User feedback] Cannot update users from CSV](https://app.clickup.com/t/8695ujvwy)

### :memo: Implementation

#### Round 2

After the merging of #295, a number bugs were discovered with the new table, aside of the one mentioned [here](https://github.com/EyeSeeTea/user-extended-app/pull/302#issuecomment-2401951394).

- The "Overwrite existing users" switch didn't trigger a new validation of the form, leading to the "Import" button to be unresponsive.
- When a user was imported without search or dataView OUs the import failed with "POST 409" due to an incorrect transformation of emptyOrgUnit (entity) into an empty OU for data. This issue also happened when the instance OU doesn't have a code (its not mandatory).
- A new user could be imported with an empty password field.
- When a user was imported with empty fields for the columns of type role, group or OU it caused an uncaught exception.

To Do:
- Validate new users for repeated names (now it only checks for overwrite names). For now, if a username is duplicated the import will fail with "Usernames must be unique".

  I didn't manage to implement this via the form validations because the error appeared in the fields but the formState errors didn't updated until the next form interaction, i.e.: when writing a second duplicated username the field was set to "red" but the top corner error message appeared when writing a char in some field (username or other).
@eperedo if you have time try to give it a go.

#### Round 1
A bug was reported that a CSV import will remove the imported users group membership. A subsequent import will restore the membership.

This bug is not dependent on the DHIS2 version and was replicated in DHIS 2.37 and 2.38.

The cause of the issue was that the users object had the following structure for `userGroups` :
```typescript
{
  id: Id,
  displayName: string
}
```
When comparing with `existingUsersToUpdate`, its `userGroups` has only the id property. 
This means that the comparison via  `_.differenceWith(existingUser?.userGroups, user.userGroups, _.isEqual)` treats the same membership as a difference because of the `displayName` prop.

Now, the `getUsersToSave` function will return the user object with the unnecessary properties removed.

Also, a check was added for the metadata POST status to avoid running `updateUserGroups` if the POST fails.

### :video_camera: Screenshots/Screen capture

The capture starts after the CSV is loaded because the orgUnit call takes its time, the same CSV export of the user is used in both cases.

### :fire: Testing

Export some users (optionally add a new one in CSV and/or import table), import them back, check that the userGroups are the same for the existing users after the import.
