### PR TITLE
Add selector for access to settings

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-01-29T06:45:26.706Z\n"
-"PO-Revision-Date: 2025-01-29T06:45:26.706Z\n"
+"POT-Creation-Date: 2025-02-15T16:06:38.749Z\n"
+"PO-Revision-Date: 2025-02-15T16:06:38.749Z\n"
 
 msgid "ID"
 msgstr ""
@@ -294,6 +294,12 @@ msgid "Show only users assigned to users' organisation units"
 msgstr ""
 
 msgid "Show only active users"
+msgstr ""
+
+msgid "Access to Settings Section"
+msgstr ""
+
+msgid "Changes on 'Who has access' to settings will be reflected after page reload"
 msgstr ""
 
 msgid "Saving..."

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2025-01-19T03:46:49.854Z\n"
+"POT-Creation-Date: 2025-02-15T16:06:38.749Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -295,9 +295,17 @@ msgid "Show feedback button"
 msgstr "Mostrar botón de feedback"
 
 msgid "Show only users assigned to users' organisation units"
-msgstr "Mostrar solo los usuarios asignados a las unidades organizativas del usuario"
+msgstr ""
+"Mostrar solo los usuarios asignados a las unidades organizativas del usuario"
 
 msgid "Show only active users"
+msgstr ""
+
+msgid "Access to Settings Section"
+msgstr ""
+
+msgid ""
+"Changes on 'Who has access' to settings will be reflected after page reload"
 msgstr ""
 
 msgid "Saving..."

--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -33,6 +33,7 @@ import { SaveAppSettingsUseCase } from "./domain/usecases/SaveAppSettingsUseCase
 import { ResetUsersPasswordsUseCase } from "./domain/usecases/ResetUsersPasswordsUseCase";
 import { SearchUsersAndUserGroupsUseCase } from "./domain/usecases/SearchUsersAndUserGroupsUseCase";
 import { UserSearchD2Repository } from "./data/repositories/UserSearchD2Repository";
+import { CheckCurrentUserCanAccessSettingsUseCase } from "./domain/usecases/CheckCurrentUserCanAccessSettingsUseCase";
 
 export function getCompositionRoot(instance: Instance) {
     const api = getD2APiFromInstance(instance);
@@ -72,6 +73,10 @@ export function getCompositionRoot(instance: Instance) {
             import: new ImportUsersUseCase(userRepository),
             resetPasswords: new ResetUsersPasswordsUseCase(userRepository),
             searchUsersAndGroups: new SearchUsersAndUserGroupsUseCase(userAndUserGroupsSearchRepository),
+            checkCurrentUserCanAccessSettings: new CheckCurrentUserCanAccessSettingsUseCase(
+                userRepository,
+                appSettingsRepository
+            ),
         }),
         metadata: getExecute({
             list: new ListMetadataUseCase(metadataRepository),

--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -31,6 +31,8 @@ import { GetAppSettingsUseCase } from "./domain/usecases/GetAppSettingsUseCase";
 import { AppSettingsD2Repository } from "./data/repositories/AppSettingsD2Repository";
 import { SaveAppSettingsUseCase } from "./domain/usecases/SaveAppSettingsUseCase";
 import { ResetUsersPasswordsUseCase } from "./domain/usecases/ResetUsersPasswordsUseCase";
+import { SearchUsersAndUserGroupsUseCase } from "./domain/usecases/SearchUsersAndUserGroupsUseCase";
+import { UserSearchD2Repository } from "./data/repositories/UserSearchD2Repository";
 
 export function getCompositionRoot(instance: Instance) {
     const api = getD2APiFromInstance(instance);
@@ -40,6 +42,7 @@ export function getCompositionRoot(instance: Instance) {
     const programRepository = new ProgramD2Repository(api);
     const loggerSettingsRepository = new LoggerSettingsD2Repository(instance);
     const appSettingsRepository = new AppSettingsD2Repository(api);
+    const userAndUserGroupsSearchRepository = new UserSearchD2Repository(api);
 
     return {
         logger: {
@@ -68,6 +71,7 @@ export function getCompositionRoot(instance: Instance) {
             copyInUser: new CopyInUserUseCase(userRepository),
             import: new ImportUsersUseCase(userRepository),
             resetPasswords: new ResetUsersPasswordsUseCase(userRepository),
+            searchUsersAndGroups: new SearchUsersAndUserGroupsUseCase(userAndUserGroupsSearchRepository),
         }),
         metadata: getExecute({
             list: new ListMetadataUseCase(metadataRepository),

--- a/src/data/repositories/AppSettingsD2Repository.ts
+++ b/src/data/repositories/AppSettingsD2Repository.ts
@@ -18,29 +18,14 @@ export class AppSettingsD2Repository implements AppSettingsRepository {
     }
 
     save(appSettings: AppSettings): FutureData<AppSettings> {
-        return this.getSettings().flatMap(existingSettings => {
-            const updatedSettings = AppSettings.create({
-                ...(existingSettings || {}),
-                columns: appSettings.columns,
-                showOnlyActiveUsers: appSettings.showOnlyActiveUsers,
-                showFeedback: appSettings.showFeedback,
-                showOnlyUsersOrgUnits: appSettings.showOnlyUsersOrgUnits,
-            });
-
-            return this.dataStorage.saveObject(this.settingsKey, updatedSettings).map(() => updatedSettings);
-        });
+        return this.dataStorage.saveObject(this.settingsKey, appSettings).map(() => appSettings);
     }
 
     private getSettings() {
-        return this.dataStorage.getObject<AppSettings>(this.settingsKey).map(d2Response =>
-            d2Response
-                ? AppSettings.create({
-                      columns: d2Response.columns,
-                      showOnlyActiveUsers: d2Response.showOnlyActiveUsers,
-                      showFeedback: d2Response.showFeedback,
-                      showOnlyUsersOrgUnits: d2Response.showOnlyUsersOrgUnits,
-                  })
-                : AppSettings.emptySettings()
-        );
+        const emptySettings = AppSettings.emptySettings();
+
+        return this.dataStorage
+            .getObject<Partial<AppSettings>>(this.settingsKey)
+            .map(d2Response => (d2Response ? AppSettings.create({ ...emptySettings, ...d2Response }) : emptySettings));
     }
 }

--- a/src/data/repositories/UserSearchD2Repository.ts
+++ b/src/data/repositories/UserSearchD2Repository.ts
@@ -7,10 +7,10 @@ import { apiToFuture } from "../../utils/futures";
 export class UserSearchD2Repository implements UserSearchRepository {
     constructor(private api: D2Api) {}
 
-    search(query: string): FutureData<UserSearch> {
+    search(name: string): FutureData<UserSearch> {
         const options = {
             fields: { id: true, displayName: true },
-            filter: { displayName: { ilike: query } },
+            filter: { displayName: { ilike: name } },
         };
 
         return apiToFuture(this.api.metadata.get({ users: options, userGroups: options })).map(userSearch => ({

--- a/src/data/repositories/UserSearchD2Repository.ts
+++ b/src/data/repositories/UserSearchD2Repository.ts
@@ -13,6 +13,9 @@ export class UserSearchD2Repository implements UserSearchRepository {
             filter: { displayName: { ilike: query } },
         };
 
-        return apiToFuture<UserSearch>(this.api.metadata.get({ users: options, userGroups: options }));
+        return apiToFuture(this.api.metadata.get({ users: options, userGroups: options })).map(userSearch => ({
+            users: userSearch.users.map(user => ({ id: user.id, name: user.displayName })),
+            userGroups: userSearch.userGroups.map(userGroup => ({ id: userGroup.id, name: userGroup.displayName })),
+        }));
     }
 }

--- a/src/data/repositories/UserSearchD2Repository.ts
+++ b/src/data/repositories/UserSearchD2Repository.ts
@@ -1,0 +1,18 @@
+import { D2Api } from "@eyeseetea/d2-api/2.36";
+import { UserSearchRepository } from "../../domain/repositories/UserSearchRepository";
+import { UserSearch } from "../../domain/entities/UserSearch";
+import { FutureData } from "../../domain/entities/Future";
+import { apiToFuture } from "../../utils/futures";
+
+export class UserSearchD2Repository implements UserSearchRepository {
+    constructor(private api: D2Api) {}
+
+    search(query: string): FutureData<UserSearch> {
+        const options = {
+            fields: { id: true, displayName: true },
+            filter: { displayName: { ilike: query } },
+        };
+
+        return apiToFuture<UserSearch>(this.api.metadata.get({ users: options, userGroups: options }));
+    }
+}

--- a/src/domain/entities/AppSettings.ts
+++ b/src/domain/entities/AppSettings.ts
@@ -21,7 +21,7 @@ export class AppSettings extends Struct<AppSettingsAttr>() {
             showOnlyActiveUsers: false,
             showOnlyUsersOrgUnits: false,
             showFeedback: true,
-            settingsAccess: { publicAccess: "rw------", users: [], userGroups: [] },
+            settingsAccess: { users: [], userGroups: [] },
         });
     }
 

--- a/src/domain/entities/AppSettings.ts
+++ b/src/domain/entities/AppSettings.ts
@@ -1,4 +1,5 @@
 import { Struct } from "./generic/Struct";
+import { Permission } from "./Permission";
 import { UserColumns } from "./User";
 
 type AppSettingsAttr = {
@@ -6,6 +7,7 @@ type AppSettingsAttr = {
     showOnlyActiveUsers: boolean;
     showOnlyUsersOrgUnits: boolean;
     showFeedback: boolean;
+    settingsAccess: Permission;
 };
 
 export type ColumnSettingValue = "visible" | "disabled" | "optional";
@@ -19,6 +21,7 @@ export class AppSettings extends Struct<AppSettingsAttr>() {
             showOnlyActiveUsers: false,
             showOnlyUsersOrgUnits: false,
             showFeedback: true,
+            settingsAccess: { publicAccess: "rw------", users: [], userGroups: [] },
         });
     }
 

--- a/src/domain/entities/Permission.ts
+++ b/src/domain/entities/Permission.ts
@@ -1,0 +1,7 @@
+import { NamedRef } from "./Ref";
+
+export type Permission = {
+    publicAccess: string; // '--------' | 'r-------'  | 'rw------'
+    users: NamedRef[];
+    userGroups: NamedRef[];
+};

--- a/src/domain/entities/Permission.ts
+++ b/src/domain/entities/Permission.ts
@@ -1,7 +1,39 @@
+import _ from "lodash";
+import { Struct } from "./generic/Struct";
 import { NamedRef } from "./Ref";
 
 export type Permission = {
-    publicAccess: string; // '--------' | 'r-------'  | 'rw------'
     users: NamedRef[];
     userGroups: NamedRef[];
 };
+
+type PublicPermissionAttrs = Permission & {
+    publicAccess: AccessValue;
+};
+
+export class PublicPermission extends Struct<PublicPermissionAttrs>() {
+    updateUsers(users: NamedRef[]): PublicPermission {
+        return this._update({
+            users,
+            publicAccess: _.isEmpty(users) && _.isEmpty(this.userGroups) ? AccessValue.public() : AccessValue.private(),
+        });
+    }
+
+    updateUserGroups(userGroups: NamedRef[]): PublicPermission {
+        return this._update({
+            userGroups,
+            publicAccess: _.isEmpty(this.users) && _.isEmpty(userGroups) ? AccessValue.public() : AccessValue.private(),
+        });
+    }
+}
+
+// Posibility of adding write access if needed in future
+class AccessValue extends Struct<{ read: boolean }>() {
+    static public() {
+        return new AccessValue({ read: true });
+    }
+
+    static private() {
+        return new AccessValue({ read: false });
+    }
+}

--- a/src/domain/entities/Ref.ts
+++ b/src/domain/entities/Ref.ts
@@ -7,3 +7,7 @@ export interface Ref {
 export interface NamedRef extends Ref {
     name: string;
 }
+
+export function getId(ref: Ref) {
+    return ref.id;
+}

--- a/src/domain/entities/UserSearch.ts
+++ b/src/domain/entities/UserSearch.ts
@@ -1,6 +1,6 @@
 type UserSearchItem = {
     id: string;
-    displayName: string;
+    name: string;
 };
 
 export type UserSearch = {

--- a/src/domain/entities/UserSearch.ts
+++ b/src/domain/entities/UserSearch.ts
@@ -1,0 +1,9 @@
+type UserSearchItem = {
+    id: string;
+    displayName: string;
+};
+
+export type UserSearch = {
+    users: UserSearchItem[];
+    userGroups: UserSearchItem[];
+};

--- a/src/domain/repositories/UserSearchRepository.ts
+++ b/src/domain/repositories/UserSearchRepository.ts
@@ -2,5 +2,5 @@ import { FutureData } from "../entities/Future";
 import { UserSearch } from "../entities/UserSearch";
 
 export interface UserSearchRepository {
-    search(query: string): FutureData<UserSearch>;
+    search(name: string): FutureData<UserSearch>;
 }

--- a/src/domain/repositories/UserSearchRepository.ts
+++ b/src/domain/repositories/UserSearchRepository.ts
@@ -1,0 +1,6 @@
+import { FutureData } from "../entities/Future";
+import { UserSearch } from "../entities/UserSearch";
+
+export interface UserSearchRepository {
+    search(query: string): FutureData<UserSearch>;
+}

--- a/src/domain/usecases/CheckCurrentUserCanAccessSettingsUseCase.ts
+++ b/src/domain/usecases/CheckCurrentUserCanAccessSettingsUseCase.ts
@@ -1,0 +1,28 @@
+import { UserRepository } from "../repositories/UserRepository";
+import { AppSettingsRepository } from "../repositories/AppSettingsRepository";
+import { Future, FutureData } from "../entities/Future";
+import { AppSettings } from "../entities/AppSettings";
+import { User } from "../entities/User";
+import { getId } from "../entities/Ref";
+
+export class CheckCurrentUserCanAccessSettingsUseCase {
+    constructor(private userRepository: UserRepository, private appSettingsRepository: AppSettingsRepository) {}
+
+    execute(): FutureData<boolean> {
+        return Future.joinObj({
+            user: this.userRepository.getCurrent(),
+            appSettings: this.appSettingsRepository.get(),
+        }).map(({ user, appSettings }) => this.checkUserCanAccessSettings(user, appSettings));
+    }
+
+    private checkUserCanAccessSettings(user: User, appSettings: AppSettings): boolean {
+        const permissions = appSettings.settingsAccess;
+        const publicAccess = permissions.publicAccess.startsWith("r");
+        const directAccess = permissions.users.some(u => u.id === user.id);
+        const groupAccess = permissions.userGroups.some(({ id: permissionUserGroupId }) =>
+            user.userGroups.map(getId).includes(permissionUserGroupId)
+        );
+
+        return publicAccess || directAccess || groupAccess;
+    }
+}

--- a/src/domain/usecases/CheckCurrentUserCanAccessSettingsUseCase.ts
+++ b/src/domain/usecases/CheckCurrentUserCanAccessSettingsUseCase.ts
@@ -2,7 +2,7 @@ import { UserRepository } from "../repositories/UserRepository";
 import { AppSettingsRepository } from "../repositories/AppSettingsRepository";
 import { Future, FutureData } from "../entities/Future";
 import { AppSettings } from "../entities/AppSettings";
-import { User } from "../entities/User";
+import { isSuperAdmin, User } from "../entities/User";
 import { getId } from "../entities/Ref";
 
 export class CheckCurrentUserCanAccessSettingsUseCase {
@@ -16,6 +16,7 @@ export class CheckCurrentUserCanAccessSettingsUseCase {
     }
 
     private checkUserCanAccessSettings(user: User, appSettings: AppSettings): boolean {
+        if (isSuperAdmin(user)) return true;
         const permissions = appSettings.settingsAccess;
         const publicAccess = permissions.publicAccess.startsWith("r");
         const directAccess = permissions.users.some(u => u.id === user.id);

--- a/src/domain/usecases/CheckCurrentUserCanAccessSettingsUseCase.ts
+++ b/src/domain/usecases/CheckCurrentUserCanAccessSettingsUseCase.ts
@@ -18,12 +18,11 @@ export class CheckCurrentUserCanAccessSettingsUseCase {
     private checkUserCanAccessSettings(user: User, appSettings: AppSettings): boolean {
         if (isSuperAdmin(user)) return true;
         const permissions = appSettings.settingsAccess;
-        const publicAccess = permissions.publicAccess.startsWith("r");
-        const directAccess = permissions.users.some(u => u.id === user.id);
+        const userAccess = permissions.users.some(u => u.id === user.id);
         const groupAccess = permissions.userGroups.some(({ id: permissionUserGroupId }) =>
             user.userGroups.map(getId).includes(permissionUserGroupId)
         );
 
-        return publicAccess || directAccess || groupAccess;
+        return userAccess || groupAccess;
     }
 }

--- a/src/domain/usecases/SearchUsersAndUserGroupsUseCase.ts
+++ b/src/domain/usecases/SearchUsersAndUserGroupsUseCase.ts
@@ -6,7 +6,7 @@ import { UserSearchRepository } from "../repositories/UserSearchRepository";
 export class SearchUsersAndUserGroupsUseCase implements UseCase {
     constructor(private userSearchRepository: UserSearchRepository) {}
 
-    public execute(query: string): FutureData<UserSearch> {
-        return this.userSearchRepository.search(query);
+    public execute(name: string): FutureData<UserSearch> {
+        return this.userSearchRepository.search(name);
     }
 }

--- a/src/domain/usecases/SearchUsersAndUserGroupsUseCase.ts
+++ b/src/domain/usecases/SearchUsersAndUserGroupsUseCase.ts
@@ -1,0 +1,12 @@
+import { UseCase } from "../../CompositionRoot";
+import { FutureData } from "../entities/Future";
+import { UserSearch } from "../entities/UserSearch";
+import { UserSearchRepository } from "../repositories/UserSearchRepository";
+
+export class SearchUsersAndUserGroupsUseCase implements UseCase {
+    constructor(private userSearchRepository: UserSearchRepository) {}
+
+    public execute(query: string): FutureData<UserSearch> {
+        return this.userSearchRepository.search(query);
+    }
+}

--- a/src/webapp/components/permissions-page/PermissionsPage.tsx
+++ b/src/webapp/components/permissions-page/PermissionsPage.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Box, Button, DialogActions, FormControlLabel, Switch, useTheme } from "@material-ui/core";
+import { InfoOutlined as InfoOutlinedIcon } from "@material-ui/icons";
 import { Sharing } from "@eyeseetea/d2-ui-components";
 import { AppSettings } from "../../../domain/entities/AppSettings";
 import { useSharingSettings } from "./useSharingSettings";
@@ -59,7 +60,18 @@ export const PermissionsPage = React.memo((props: PermissionsPageProps) => {
                             disabled={showSharingSettings}
                         />
                     }
-                    label={i18n.t("Access to Settings Section")}
+                    label={
+                        <Box display="flex" alignItems="flex-start" gridColumnGap={theme.spacing(0.5)}>
+                            {i18n.t("Access to Settings Section")}
+                            <InfoOutlinedIcon
+                                fontSize="small"
+                                color="disabled"
+                                titleAccess={i18n.t(
+                                    "Changes on 'Who has access' to settings will be reflected after page reload"
+                                )}
+                            />
+                        </Box>
+                    }
                 />
             </Box>
 

--- a/src/webapp/components/permissions-page/PermissionsPage.tsx
+++ b/src/webapp/components/permissions-page/PermissionsPage.tsx
@@ -1,7 +1,11 @@
+import _ from "lodash";
 import React from "react";
 import { Box, Button, DialogActions, FormControlLabel, Switch, useTheme } from "@material-ui/core";
-
+import { MetaObject, SharedObject, ShareUpdate, Sharing, SharingRule } from "@eyeseetea/d2-ui-components";
 import { AppSettings } from "../../../domain/entities/AppSettings";
+import { useAppContext } from "../../contexts/app-context";
+import { NamedRef } from "../../../domain/entities/Ref";
+import { useAppSettingsContext } from "../../contexts/AppSettingsProvider";
 import i18n from "../../../locales";
 
 type PermissionsPageProps = { appSettings: AppSettings; onSave: (appSettings: AppSettings) => void };
@@ -10,11 +14,15 @@ export const PermissionsPage = React.memo((props: PermissionsPageProps) => {
     const { appSettings, onSave } = props;
 
     const theme = useTheme();
+    const { search, metaObject, onUpdateSharingOptions, permission } = useSharingSettings();
+
+    const showSharingSettings = !_.isEmpty(permission.users) || !_.isEmpty(permission.userGroups);
 
     const [formState, setForm] = React.useState<FormType>({
         activeUsers: appSettings.showOnlyActiveUsers,
         usersOrgUnits: appSettings.showOnlyUsersOrgUnits,
         feedbackButton: appSettings.showFeedback,
+        showSharingSettings: showSharingSettings,
     });
 
     const updateFormState = (value: boolean, field: keyof FormType) => {
@@ -28,9 +36,10 @@ export const PermissionsPage = React.memo((props: PermissionsPageProps) => {
                 showOnlyActiveUsers: formState.activeUsers,
                 showOnlyUsersOrgUnits: formState.usersOrgUnits,
                 showFeedback: formState.feedbackButton,
+                settingsAccess: permission,
             })
         );
-    }, [formState, appSettings, onSave]);
+    }, [onSave, appSettings, formState, permission]);
 
     return (
         <Box component="section" padding={theme.spacing(0.25)}>
@@ -44,6 +53,7 @@ export const PermissionsPage = React.memo((props: PermissionsPageProps) => {
                     }
                     label={i18n.t("Show feedback button")}
                 />
+
                 <FormControlLabel
                     control={
                         <Switch
@@ -53,6 +63,7 @@ export const PermissionsPage = React.memo((props: PermissionsPageProps) => {
                     }
                     label={i18n.t("Show only users assigned to users' organisation units")}
                 />
+
                 <FormControlLabel
                     control={
                         <Switch
@@ -62,7 +73,31 @@ export const PermissionsPage = React.memo((props: PermissionsPageProps) => {
                     }
                     label={i18n.t("Show only active users")}
                 />
+
+                <FormControlLabel
+                    control={
+                        <Switch
+                            checked={formState.showSharingSettings}
+                            onChange={event =>
+                                !showSharingSettings && updateFormState(event.target.checked, "showSharingSettings")
+                            }
+                            disabled={showSharingSettings}
+                        />
+                    }
+                    label={i18n.t("Access to Settings Section")}
+                />
             </Box>
+
+            {formState.showSharingSettings && (
+                <Box paddingX={theme.spacing(0.25)} marginBottom={2}>
+                    <Sharing
+                        meta={metaObject}
+                        showOptions={sharingOptions}
+                        onSearch={search}
+                        onChange={onUpdateSharingOptions}
+                    />
+                </Box>
+            )}
 
             <DialogActions>
                 <Button onClick={onSaveSettings} color="primary" variant="contained">
@@ -73,4 +108,59 @@ export const PermissionsPage = React.memo((props: PermissionsPageProps) => {
     );
 });
 
-type FormType = { activeUsers: boolean; usersOrgUnits: boolean; feedbackButton: boolean };
+type FormType = { activeUsers: boolean; usersOrgUnits: boolean; feedbackButton: boolean; showSharingSettings: boolean };
+
+function useSharingSettings() {
+    const { compositionRoot } = useAppContext();
+    const { appSettings } = useAppSettingsContext();
+
+    const [permission, setPermission] = React.useState(appSettings.settingsAccess);
+
+    const sharedObject: SharedObject = React.useMemo(
+        () => ({
+            id: "",
+            userAccesses: mapSharingRule(permission.users),
+            userGroupAccesses: mapSharingRule(permission.userGroups),
+            publicAccess: permission.publicAccess,
+        }),
+        [permission.publicAccess, permission.userGroups, permission.users]
+    );
+
+    const metaObject: MetaObject = React.useMemo(() => ({ object: sharedObject }), [sharedObject]);
+
+    const search = React.useCallback(
+        (query: string) => compositionRoot.users.searchUsersAndGroups(query).toPromise(),
+        [compositionRoot]
+    );
+
+    const onUpdateSharingOptions = React.useCallback(
+        /* Marked async only because it is typed that way on the Sharing props */
+        async ({ userAccesses, userGroupAccesses }: ShareUpdate) => {
+            const isLimited = !_.isEmpty(userAccesses) || !_.isEmpty(userGroupAccesses);
+
+            setPermission(permissions => ({
+                users: userAccesses ? mapAccessPermission(userAccesses) : permissions.users,
+                userGroups: userGroupAccesses ? mapAccessPermission(userGroupAccesses) : permissions.userGroups,
+                publicAccess: isLimited ? "--------" : "rw------",
+            }));
+        },
+        [setPermission]
+    );
+
+    return { search, metaObject, onUpdateSharingOptions, permission };
+}
+
+const mapAccessPermission = (rules: SharingRule[]): NamedRef[] => {
+    return rules.map(item => ({ id: item.id, name: item.displayName }));
+};
+
+const mapSharingRule = (rules: NamedRef[]): SharingRule[] => {
+    return rules.map(item => ({ id: item.id, access: "rw------", displayName: item.name }));
+};
+
+const sharingOptions = {
+    dataSharing: false,
+    publicSharing: false,
+    externalSharing: false,
+    permissionPicker: false,
+};

--- a/src/webapp/components/permissions-page/PermissionsPage.tsx
+++ b/src/webapp/components/permissions-page/PermissionsPage.tsx
@@ -1,45 +1,20 @@
-import _ from "lodash";
 import React from "react";
 import { Box, Button, DialogActions, FormControlLabel, Switch, useTheme } from "@material-ui/core";
-import { MetaObject, SharedObject, ShareUpdate, Sharing, SharingRule } from "@eyeseetea/d2-ui-components";
+import { Sharing } from "@eyeseetea/d2-ui-components";
 import { AppSettings } from "../../../domain/entities/AppSettings";
-import { useAppContext } from "../../contexts/app-context";
-import { NamedRef } from "../../../domain/entities/Ref";
-import { useAppSettingsContext } from "../../contexts/AppSettingsProvider";
+import { useSharingSettings } from "./useSharingSettings";
+import { usePermissionsPage } from "./usePermissionsPage";
 import i18n from "../../../locales";
 
-type PermissionsPageProps = { appSettings: AppSettings; onSave: (appSettings: AppSettings) => void };
+type PermissionsPageProps = { onSave: (appSettings: AppSettings) => void };
 
 export const PermissionsPage = React.memo((props: PermissionsPageProps) => {
-    const { appSettings, onSave } = props;
+    const { onSave } = props;
+
+    const { search, metaObject, onUpdateSharingOptions, permission } = useSharingSettings();
+    const { formState, updateFormState, onSaveSettings, showSharingSettings } = usePermissionsPage(onSave, permission);
 
     const theme = useTheme();
-    const { search, metaObject, onUpdateSharingOptions, permission } = useSharingSettings();
-
-    const showSharingSettings = !_.isEmpty(permission.users) || !_.isEmpty(permission.userGroups);
-
-    const [formState, setForm] = React.useState<FormType>({
-        activeUsers: appSettings.showOnlyActiveUsers,
-        usersOrgUnits: appSettings.showOnlyUsersOrgUnits,
-        feedbackButton: appSettings.showFeedback,
-        showSharingSettings: showSharingSettings,
-    });
-
-    const updateFormState = (value: boolean, field: keyof FormType) => {
-        setForm(prev => ({ ...prev, [field]: value }));
-    };
-
-    const onSaveSettings = React.useCallback(() => {
-        onSave(
-            AppSettings.create({
-                ...appSettings,
-                showOnlyActiveUsers: formState.activeUsers,
-                showOnlyUsersOrgUnits: formState.usersOrgUnits,
-                showFeedback: formState.feedbackButton,
-                settingsAccess: permission,
-            })
-        );
-    }, [onSave, appSettings, formState, permission]);
 
     return (
         <Box component="section" padding={theme.spacing(0.25)}>
@@ -107,56 +82,6 @@ export const PermissionsPage = React.memo((props: PermissionsPageProps) => {
         </Box>
     );
 });
-
-type FormType = { activeUsers: boolean; usersOrgUnits: boolean; feedbackButton: boolean; showSharingSettings: boolean };
-
-function useSharingSettings() {
-    const { compositionRoot } = useAppContext();
-    const { appSettings } = useAppSettingsContext();
-
-    const [permission, setPermission] = React.useState(appSettings.settingsAccess);
-
-    const sharedObject: SharedObject = React.useMemo(
-        () => ({
-            id: "",
-            userAccesses: mapSharingRule(permission.users),
-            userGroupAccesses: mapSharingRule(permission.userGroups),
-            publicAccess: permission.publicAccess,
-        }),
-        [permission.publicAccess, permission.userGroups, permission.users]
-    );
-
-    const metaObject: MetaObject = React.useMemo(() => ({ object: sharedObject }), [sharedObject]);
-
-    const search = React.useCallback(
-        (query: string) => compositionRoot.users.searchUsersAndGroups(query).toPromise(),
-        [compositionRoot]
-    );
-
-    const onUpdateSharingOptions = React.useCallback(
-        /* Marked async only because it is typed that way on the Sharing props */
-        async ({ userAccesses, userGroupAccesses }: ShareUpdate) => {
-            const isLimited = !_.isEmpty(userAccesses) || !_.isEmpty(userGroupAccesses);
-
-            setPermission(permissions => ({
-                users: userAccesses ? mapAccessPermission(userAccesses) : permissions.users,
-                userGroups: userGroupAccesses ? mapAccessPermission(userGroupAccesses) : permissions.userGroups,
-                publicAccess: isLimited ? "--------" : "rw------",
-            }));
-        },
-        [setPermission]
-    );
-
-    return { search, metaObject, onUpdateSharingOptions, permission };
-}
-
-const mapAccessPermission = (rules: SharingRule[]): NamedRef[] => {
-    return rules.map(item => ({ id: item.id, name: item.displayName }));
-};
-
-const mapSharingRule = (rules: NamedRef[]): SharingRule[] => {
-    return rules.map(item => ({ id: item.id, access: "rw------", displayName: item.name }));
-};
 
 const sharingOptions = {
     dataSharing: false,

--- a/src/webapp/components/permissions-page/usePermissionsPage.ts
+++ b/src/webapp/components/permissions-page/usePermissionsPage.ts
@@ -1,0 +1,43 @@
+import _ from "lodash";
+import React from "react";
+import { AppSettings } from "../../../domain/entities/AppSettings";
+import { useAppSettingsContext } from "../../contexts/AppSettingsProvider";
+import { Permission } from "../../../domain/entities/Permission";
+
+export const usePermissionsPage = (onSave: (appSettings: AppSettings) => void, permission: Permission) => {
+    const { appSettings } = useAppSettingsContext();
+
+    const showSharingSettings = !_.isEmpty(permission.users) || !_.isEmpty(permission.userGroups);
+
+    const [formState, setForm] = React.useState<FormType>({
+        activeUsers: appSettings.showOnlyActiveUsers,
+        usersOrgUnits: appSettings.showOnlyUsersOrgUnits,
+        feedbackButton: appSettings.showFeedback,
+        showSharingSettings: showSharingSettings,
+    });
+
+    const updateFormState = (value: boolean, field: keyof FormType) => {
+        setForm(prev => ({ ...prev, [field]: value }));
+    };
+
+    const onSaveSettings = React.useCallback(() => {
+        onSave(
+            AppSettings.create({
+                ...appSettings,
+                showOnlyActiveUsers: formState.activeUsers,
+                showOnlyUsersOrgUnits: formState.usersOrgUnits,
+                showFeedback: formState.feedbackButton,
+                settingsAccess: permission,
+            })
+        );
+    }, [onSave, appSettings, formState, permission]);
+
+    return {
+        formState,
+        updateFormState,
+        onSaveSettings,
+        showSharingSettings,
+    };
+};
+
+type FormType = { activeUsers: boolean; usersOrgUnits: boolean; feedbackButton: boolean; showSharingSettings: boolean };

--- a/src/webapp/components/permissions-page/useSharingSettings.ts
+++ b/src/webapp/components/permissions-page/useSharingSettings.ts
@@ -25,7 +25,17 @@ export function useSharingSettings() {
     const metaObject: MetaObject = React.useMemo(() => ({ object: sharedObject }), [sharedObject]);
 
     const search = React.useCallback(
-        (query: string) => compositionRoot.users.searchUsersAndGroups(query).toPromise(),
+        (query: string) =>
+            compositionRoot.users
+                .searchUsersAndGroups(query)
+                .map(userSearch => ({
+                    users: userSearch.users.map(user => ({ id: user.id, displayName: user.name })),
+                    userGroups: userSearch.userGroups.map(userGroup => ({
+                        id: userGroup.id,
+                        displayName: userGroup.name,
+                    })),
+                }))
+                .toPromise(),
         [compositionRoot]
     );
 

--- a/src/webapp/components/permissions-page/useSharingSettings.ts
+++ b/src/webapp/components/permissions-page/useSharingSettings.ts
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import React from "react";
 import { MetaObject, SharedObject, ShareUpdate, SharingRule } from "@eyeseetea/d2-ui-components";
 import { useAppContext } from "../../contexts/app-context";
@@ -17,9 +16,8 @@ export function useSharingSettings() {
             id: "",
             userAccesses: mapSharingRule(permission.users),
             userGroupAccesses: mapSharingRule(permission.userGroups),
-            publicAccess: permission.publicAccess,
         }),
-        [permission.publicAccess, permission.userGroups, permission.users]
+        [permission.userGroups, permission.users]
     );
 
     const metaObject: MetaObject = React.useMemo(() => ({ object: sharedObject }), [sharedObject]);
@@ -42,12 +40,9 @@ export function useSharingSettings() {
     const onUpdateSharingOptions = React.useCallback(
         /* Marked async only because it is typed that way on the Sharing props */
         async ({ userAccesses, userGroupAccesses }: ShareUpdate) => {
-            const isLimited = !_.isEmpty(userAccesses) || !_.isEmpty(userGroupAccesses);
-
             setPermission(permissions => ({
                 users: userAccesses ? mapAccessPermission(userAccesses) : permissions.users,
                 userGroups: userGroupAccesses ? mapAccessPermission(userGroupAccesses) : permissions.userGroups,
-                publicAccess: isLimited ? "--------" : "rw------",
             }));
         },
         [setPermission]

--- a/src/webapp/components/permissions-page/useSharingSettings.ts
+++ b/src/webapp/components/permissions-page/useSharingSettings.ts
@@ -1,0 +1,55 @@
+import _ from "lodash";
+import React from "react";
+import { MetaObject, SharedObject, ShareUpdate, SharingRule } from "@eyeseetea/d2-ui-components";
+import { useAppContext } from "../../contexts/app-context";
+import { NamedRef } from "../../../domain/entities/Ref";
+import { useAppSettingsContext } from "../../contexts/AppSettingsProvider";
+import { Permission } from "../../../domain/entities/Permission";
+
+export function useSharingSettings() {
+    const { compositionRoot } = useAppContext();
+    const { appSettings } = useAppSettingsContext();
+
+    const [permission, setPermission] = React.useState<Permission>(appSettings.settingsAccess);
+
+    const sharedObject: SharedObject = React.useMemo(
+        () => ({
+            id: "",
+            userAccesses: mapSharingRule(permission.users),
+            userGroupAccesses: mapSharingRule(permission.userGroups),
+            publicAccess: permission.publicAccess,
+        }),
+        [permission.publicAccess, permission.userGroups, permission.users]
+    );
+
+    const metaObject: MetaObject = React.useMemo(() => ({ object: sharedObject }), [sharedObject]);
+
+    const search = React.useCallback(
+        (query: string) => compositionRoot.users.searchUsersAndGroups(query).toPromise(),
+        [compositionRoot]
+    );
+
+    const onUpdateSharingOptions = React.useCallback(
+        /* Marked async only because it is typed that way on the Sharing props */
+        async ({ userAccesses, userGroupAccesses }: ShareUpdate) => {
+            const isLimited = !_.isEmpty(userAccesses) || !_.isEmpty(userGroupAccesses);
+
+            setPermission(permissions => ({
+                users: userAccesses ? mapAccessPermission(userAccesses) : permissions.users,
+                userGroups: userGroupAccesses ? mapAccessPermission(userGroupAccesses) : permissions.userGroups,
+                publicAccess: isLimited ? "--------" : "rw------",
+            }));
+        },
+        [setPermission]
+    );
+
+    return { search, metaObject, onUpdateSharingOptions, permission };
+}
+
+const mapAccessPermission = (rules: SharingRule[]): NamedRef[] => {
+    return rules.map(item => ({ id: item.id, name: item.displayName }));
+};
+
+const mapSharingRule = (rules: NamedRef[]): SharingRule[] => {
+    return rules.map(item => ({ id: item.id, access: "rw------", displayName: item.name }));
+};

--- a/src/webapp/components/settings-dialog-modal/SettingsDialogModal.tsx
+++ b/src/webapp/components/settings-dialog-modal/SettingsDialogModal.tsx
@@ -103,7 +103,7 @@ export const SettingsDialogModal: React.FC<SettingsDialogModalProps> = props => 
                     />
                 );
             case "permissions":
-                return <PermissionsPage onSave={onSavePermissions} appSettings={appSettings} />;
+                return <PermissionsPage onSave={onSavePermissions} />;
         }
     };
 

--- a/src/webapp/components/user-list-table/UserListTable.tsx
+++ b/src/webapp/components/user-list-table/UserListTable.tsx
@@ -130,6 +130,8 @@ export const UserListTable: React.FC<UserListTableProps> = ({
     const [showSettings, setShowSettings] = React.useState(false);
     const [showImportModal, setShowImportModal] = React.useState(false);
     const [importResult, setImportResult] = React.useState<ImportResult>();
+    const [currentUserHasAccessToSettings, setCurrentUserHasAccessToSettings] = React.useState(false);
+
     const { importSettings } = useImportSettings();
 
     const enableReplicate = hasReplicateAuthority(currentUser);
@@ -365,14 +367,14 @@ export const UserListTable: React.FC<UserListTableProps> = ({
                     isActive: () => enableReplicate,
                 },
             ],
-            globalActions: [
-                {
+            globalActions: _.compact([
+                currentUserHasAccessToSettings && {
                     name: "open-settings",
                     text: i18n.t("Settings"),
                     icon: <Tune />,
                     onClick: () => setShowSettings(true),
                 },
-            ],
+            ]),
             // TODO: Bug in ObjectsList
             initialSorting: {
                 field: "firstName",
@@ -393,7 +395,16 @@ export const UserListTable: React.FC<UserListTableProps> = ({
             // onActionButtonClick: () => navigate("/new"),
             onReorderColumns,
         };
-    }, [appSettings, enableReplicate, editUsers, onReorderColumns, reload, onAction, userColumns]);
+    }, [
+        appSettings,
+        userColumns,
+        editUsers,
+        onReorderColumns,
+        reload,
+        onAction,
+        enableReplicate,
+        currentUserHasAccessToSettings,
+    ]);
 
     const refreshRows = useCallback(
         async (
@@ -557,6 +568,12 @@ export const UserListTable: React.FC<UserListTableProps> = ({
         [setAppSettings]
     );
 
+    React.useEffect(() => {
+        compositionRoot.users
+            .checkCurrentUserCanAccessSettings()
+            .run(setCurrentUserHasAccessToSettings, snackbar.error);
+    }, [compositionRoot.users, snackbar.error]);
+
     const selectedUsers = users && users.length > 0;
 
     return (
@@ -594,7 +611,9 @@ export const UserListTable: React.FC<UserListTableProps> = ({
                 />
             )}
 
-            {showSettings && <SettingsDialogModal onClose={onSettingsClose} onCloseAppSettings={updateAppSettings} />}
+            {showSettings && currentUserHasAccessToSettings && (
+                <SettingsDialogModal onClose={onSettingsClose} onCloseAppSettings={updateAppSettings} />
+            )}
 
             <PatchPaginationTableWrapper
                 className={needsPatch ? "patched" : undefined}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes subtask https://app.clickup.com/t/8697qhzkf (main task https://app.clickup.com/t/869656vnq)

### :memo: Implementation

Added Sharing Settings component from d2-ui-components to define the list of users/user groups with access to the settings interface. If not set, access to settings will be public for everyone. Changes will occur after reloading to prevent users from losing access to settings in case they mistakenly set incorrect permissions.

### :video_camera: Screenshots/Screen capture

![image](https://github.com/user-attachments/assets/a8896ddb-2442-4d9c-8fdd-8dd8c32e24bb)
![image](https://github.com/user-attachments/assets/146dec6a-2a0d-4260-8d09-d43dbab0dbde)
