### PR TITLE
Use usergroup endpoint to add users

### DIFF
--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -412,10 +412,12 @@ export class UserD2ApiRepository implements UserRepository {
 
         const existingKeys = _(allExistingUsersGroups).keys().value();
 
-        const groupsIdsToAdd = users.flatMap(user => {
+        const groupsIdsToAddRef = users.flatMap(user => {
             const groupsRef = user.userGroups.map(userGroup => ({ id: userGroup.id }));
             return groupsRef.filter(({ id }) => !existingKeys.includes(id));
         });
+
+        const groupsIdsToAdd = _.uniqBy(groupsIdsToAddRef, ({ id }) => id);
 
         const groupsIdsToDelete = users.flatMap(user => {
             const existingUser = existing.find(({ id }) => id === user.id);

--- a/src/legacy/models/user.js
+++ b/src/legacy/models/user.js
@@ -1,7 +1,7 @@
 import { pick, merge, unzip, times } from "lodash/fp";
 import { generateUid } from "d2/lib/uid";
 import { getFromTemplate } from "../utils/template";
-import { postMetadata } from "./userHelpers";
+import { postMetadata, addUserToUserGroup } from "./userHelpers";
 
 class User {
     constructor(d2, attributes) {
@@ -77,18 +77,12 @@ class User {
         if (userJson.userCredentials?.user !== undefined) delete userJson.userCredentials.user;
 
         const newUsers = newUsersAttributes.map(newUserAttributes => merge(userJson, newUserAttributes));
-        const userGroupIds = this.attributes.userGroups.map(userGroup => userGroup.id);
-        const { userGroups } = await this.api.get("/userGroups", {
-            filter: "id:in:[" + userGroupIds.join(",") + "]",
-            fields: ":owner",
-            paging: false,
-        });
-        const userGroupsWithNewUsers = userGroups.map(userGroup => ({
-            ...userGroup,
-            users: userGroup.users.concat(newUsers.map(newUser => ({ id: newUser.id }))),
-        }));
-        const payload = { users: newUsers, userGroups: userGroupsWithNewUsers };
-        return postMetadata(this.api, payload);
+        const payload = { users: newUsers };
+
+        const response = await postMetadata(this.api, payload);
+        await addUserToUserGroup(this.d2, newUsers, this.attributes.userGroups);
+
+        return response;
     }
 
     static async getById(d2, userId) {

--- a/src/legacy/models/userHelpers.js
+++ b/src/legacy/models/userHelpers.js
@@ -583,9 +583,16 @@ async function addUserToUserGroup(d2, users, userGroups) {
         ...user,
         userGroups: userGroupIds,
     }));
-    const d2Api = getD2APiFromInstance(d2.Api.getApi());
-    const userRepository = new UserD2ApiRepository({ url: d2Api.baseUrl });
+
+    const baseUrl = getFormattedBaseUrl(d2);
+    const userRepository = new UserD2ApiRepository({ url: baseUrl });
+
     return userRepository.updateUserGroups(userEntities, []).runAsync();
+}
+
+function getFormattedBaseUrl(d2) {
+    const d2Api = d2.Api.getApi();
+    return d2Api.baseUrl.replace(/\/api\/?$/, "");
 }
 
 export {

--- a/src/legacy/models/userHelpers.js
+++ b/src/legacy/models/userHelpers.js
@@ -6,6 +6,7 @@ import { mapPromise, listWithInFilter } from "../utils/dhis2Helpers";
 import { UserD2ApiRepository } from "../../data/repositories/UserD2ApiRepository";
 import { buildUserWithoutPassword } from "../../data/utils";
 import { D2ApiLogger } from "../../data/D2ApiLogger";
+import { getD2APiFromInstance } from "../../utils/d2-api";
 
 // Delimiter to use in multiple-value fields (roles, groups, orgUnits)
 const fieldSplitChar = "||";
@@ -575,6 +576,18 @@ function getPayload(d2, parentUser, destUsers, fields, updateStrategy) {
     return saveCopyInUsers(d2, users, fields.userGroups);
 }
 
+async function addUserToUserGroup(d2, users, userGroups) {
+    const userGroupIds = userGroups.map(group => ({ id: group.id }));
+
+    const userEntities = users.map(user => ({
+        ...user,
+        userGroups: userGroupIds,
+    }));
+    const d2Api = getD2APiFromInstance(d2.Api.getApi());
+    const userRepository = new UserD2ApiRepository({ url: d2Api.baseUrl });
+    return userRepository.updateUserGroups(userEntities, []).runAsync();
+}
+
 export {
     importFromCsv,
     importFromJson,
@@ -584,4 +597,5 @@ export {
     getExistingUsers,
     getPayload,
     postMetadata,
+    addUserToUserGroup,
 };

--- a/src/legacy/models/userHelpers.js
+++ b/src/legacy/models/userHelpers.js
@@ -6,7 +6,6 @@ import { mapPromise, listWithInFilter } from "../utils/dhis2Helpers";
 import { UserD2ApiRepository } from "../../data/repositories/UserD2ApiRepository";
 import { buildUserWithoutPassword } from "../../data/utils";
 import { D2ApiLogger } from "../../data/D2ApiLogger";
-import { getD2APiFromInstance } from "../../utils/d2-api";
 
 // Delimiter to use in multiple-value fields (roles, groups, orgUnits)
 const fieldSplitChar = "||";


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #8699ad6dm [[User Extended] Replicating a user saves the user groups by sending the whole group instead of using append as in other save actions in the app](https://app.clickup.com/t/8699ad6dm)

### :memo: Implementation
- use UserRepository.updateUserGroup

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/7698d5d4-0d4e-41a3-aa25-b5ccc5a2f571


### :fire: Testing
