### PR TITLE
Point to 2.41 schemas

### DIFF
--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -23,13 +23,13 @@ import { CopyInUserUseCase } from "./domain/usecases/CopyInUserUseCase";
 import { ImportUsersUseCase } from "./domain/usecases/ImportUsersUseCase";
 import { GetProgramsUseCase } from "./domain/usecases/GetProgramsUseCase";
 import { ProgramD2Repository } from "./data/repositories/ProgramD2Repository";
-import { getD2APiFromInstance } from "./utils/d2-api";
+import { getD2ApiFromInstance } from "./utils/d2-api";
 import { LoggerSettingsD2Repository } from "./data/repositories/LoggerSettingsD2Repository";
 import { GetLoggerSettingsUseCase } from "./domain/usecases/GetLoggerSettingsUseCase";
 import { SaveLoggerSettingsUseCase } from "./domain/usecases/SaveLoggerSettingsUseCase";
 
 export function getCompositionRoot(instance: Instance) {
-    const api = getD2APiFromInstance(instance);
+    const api = getD2ApiFromInstance(instance);
     const instanceRepository = new InstanceD2ApiRepository(instance);
     const userRepository = new UserD2ApiRepository(instance);
     const metadataRepository = new MetadataD2ApiRepository(instance);

--- a/src/data/D2ApiTracker.ts
+++ b/src/data/D2ApiTracker.ts
@@ -33,9 +33,10 @@ export class D2ApiTracker {
     save(options: SaveTrackerType): FutureData<D2TeiResponse> {
         const { data, settings } = options;
         const orgUnitId = data.orgUnitId;
+        const timestamp = new Date().getTime();
         const currentDateISO = new Date().toISOString();
-        const teiId = getUid(`${data.username}_${data.orgUnitId}_tei_${new Date().getTime()}`);
-        const enrollmentId = getUid(`${data.username}_${data.orgUnitId}_enrollment_${new Date().getTime()}`);
+        const teiId = getUid(`${data.username}_${data.orgUnitId}_tei_${timestamp}`);
+        const enrollmentId = getUid(`${data.username}_${data.orgUnitId}_enrollment_${timestamp}`);
         return this.getTrackedEntityTypeByProgramId(settings.programId).flatMap(trackedEntityTypeId => {
             return apiToFuture(
                 this.api.trackedEntityInstances.post(

--- a/src/data/D2ApiTracker.ts
+++ b/src/data/D2ApiTracker.ts
@@ -1,10 +1,9 @@
 import _ from "lodash";
 import { Future, FutureData } from "../domain/entities/Future";
 import { LoggerSettings } from "../domain/entities/LoggerSettings";
-import { D2Api } from "../types/d2-api";
+import { D2Api, TeiGetRequest } from "../types/d2-api";
 import { Id } from "../domain/entities/Ref";
 import { apiToFuture } from "../utils/futures";
-import { TeiGetRequest } from "@eyeseetea/d2-api/api/trackedEntityInstances";
 import { getUid } from "../utils/uid";
 
 export class D2ApiTracker {

--- a/src/data/clients/storage/DataStoreStorageClient.ts
+++ b/src/data/clients/storage/DataStoreStorageClient.ts
@@ -1,6 +1,6 @@
 import { Future, FutureData } from "../../../domain/entities/Future";
 import { D2Api, DataStore } from "../../../types/d2-api";
-import { getD2APiFromInstance } from "../../../utils/d2-api";
+import { getD2ApiFromInstance } from "../../../utils/d2-api";
 import { apiToFuture } from "../../../utils/futures";
 import { Instance } from "../../entities/Instance";
 import { dataStoreNamespace } from "./Namespaces";
@@ -12,7 +12,7 @@ export class DataStoreStorageClient extends StorageClient {
 
     constructor(type: "user" | "global", instance: Instance) {
         super();
-        this.api = getD2APiFromInstance(instance);
+        this.api = getD2ApiFromInstance(instance);
         this.dataStore =
             type === "user" ? this.api.userDataStore(dataStoreNamespace) : this.api.dataStore(dataStoreNamespace);
     }

--- a/src/data/repositories/InstanceD2ApiRepository.ts
+++ b/src/data/repositories/InstanceD2ApiRepository.ts
@@ -1,4 +1,4 @@
-import { D2Api } from "@eyeseetea/d2-api/2.36";
+import { D2Api } from "../../types/d2-api";
 import _ from "lodash";
 import { FutureData } from "../../domain/entities/Future";
 import { Locale } from "../../domain/entities/Locale";

--- a/src/data/repositories/InstanceD2ApiRepository.ts
+++ b/src/data/repositories/InstanceD2ApiRepository.ts
@@ -4,7 +4,7 @@ import { FutureData } from "../../domain/entities/Future";
 import { Locale } from "../../domain/entities/Locale";
 import { InstanceRepository, LocaleType } from "../../domain/repositories/InstanceRepository";
 import { cache } from "../../utils/cache";
-import { getD2APiFromInstance } from "../../utils/d2-api";
+import { getD2ApiFromInstance } from "../../utils/d2-api";
 import { apiToFuture } from "../../utils/futures";
 import { Instance } from "../entities/Instance";
 
@@ -12,7 +12,7 @@ export class InstanceD2ApiRepository implements InstanceRepository {
     private api: D2Api;
 
     constructor(instance: Instance) {
-        this.api = getD2APiFromInstance(instance);
+        this.api = getD2ApiFromInstance(instance);
     }
 
     public getBaseUrl(): string {

--- a/src/data/repositories/MetadataD2ApiRepository.ts
+++ b/src/data/repositories/MetadataD2ApiRepository.ts
@@ -2,7 +2,7 @@ import { FutureData } from "../../domain/entities/Future";
 import { Instance } from "../entities/Instance";
 import { Metadata, MetadataType } from "../../domain/entities/Metadata";
 import { MetadataRepository } from "../../domain/repositories/MetadataRepository";
-import { D2Api, Pager } from "@eyeseetea/d2-api/2.36";
+import { D2Api, Pager } from "../../types/d2-api";
 import { getD2APiFromInstance } from "../../utils/d2-api";
 import { apiToFuture } from "../../utils/futures";
 import { OrgUnit } from "../../domain/entities/OrgUnit";

--- a/src/data/repositories/MetadataD2ApiRepository.ts
+++ b/src/data/repositories/MetadataD2ApiRepository.ts
@@ -3,7 +3,7 @@ import { Instance } from "../entities/Instance";
 import { Metadata, MetadataType } from "../../domain/entities/Metadata";
 import { MetadataRepository } from "../../domain/repositories/MetadataRepository";
 import { D2Api, Pager } from "../../types/d2-api";
-import { getD2APiFromInstance } from "../../utils/d2-api";
+import { getD2ApiFromInstance } from "../../utils/d2-api";
 import { apiToFuture } from "../../utils/futures";
 import { OrgUnit } from "../../domain/entities/OrgUnit";
 
@@ -11,7 +11,7 @@ export class MetadataD2ApiRepository implements MetadataRepository {
     private api: D2Api;
 
     constructor(instance: Instance) {
-        this.api = getD2APiFromInstance(instance);
+        this.api = getD2ApiFromInstance(instance);
     }
 
     public list(

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -10,7 +10,7 @@ import { UserLogic } from "../../domain/entities/UserLogic";
 import { ListOptions, UpdateStrategy, UserRepository } from "../../domain/repositories/UserRepository";
 import { Maybe } from "../../types/utils";
 import { cache } from "../../utils/cache";
-import { getD2APiFromInstance, joinPaths } from "../../utils/d2-api";
+import { getD2ApiFromInstance, joinPaths } from "../../utils/d2-api";
 import { apiToFuture } from "../../utils/futures";
 import { DataStoreStorageClient } from "../clients/storage/DataStoreStorageClient";
 import { Namespaces } from "../clients/storage/Namespaces";
@@ -26,7 +26,7 @@ export class UserD2ApiRepository implements UserRepository {
     private userStorage: StorageClient;
 
     constructor(instance: Instance) {
-        this.api = getD2APiFromInstance(instance);
+        this.api = getD2ApiFromInstance(instance);
         this.userStorage = new DataStoreStorageClient("user", instance);
     }
 

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -1,4 +1,4 @@
-import { D2Api, D2UserSchema, MetadataResponse, SelectedPick } from "../../types/d2-api";
+import { D2Api, D2UserSchema, MetadataResponse, SelectedPick, PatchOperation, ErrorReport } from "../../types/d2-api";
 import _ from "lodash";
 import { Future, FutureData } from "../../domain/entities/Future";
 import { OrgUnit } from "../../domain/entities/OrgUnit";
@@ -20,8 +20,6 @@ import { Instance } from "../entities/Instance";
 import { ApiD2OrgUnit } from "../models/DHIS2Model";
 import { ApiUserModel } from "../models/UserModel";
 import { buildUserWithoutPassword, chunkRequest, getDiffUserIdsByGroup, getErrorFromResponse } from "../utils";
-import { PatchOperation } from "@eyeseetea/d2-api/api/patch";
-import { ErrorReport } from "@eyeseetea/d2-api/api/common";
 
 export class UserD2ApiRepository implements UserRepository {
     private api: D2Api;

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -632,7 +632,14 @@ const fields = {
     organisationUnits: orgUnitsFields,
     dataViewOrganisationUnits: orgUnitsFields,
     teiSearchOrganisationUnits: orgUnitsFields,
-    access: true,
+    access: {
+        delete: true,
+        externalize: true,
+        manage: true,
+        read: true,
+        update: true,
+        write: true,
+    },
     userCredentials: {
         id: true,
         username: true,

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -1,4 +1,4 @@
-import { D2Api, D2UserSchema, MetadataResponse, SelectedPick } from "@eyeseetea/d2-api/2.36";
+import { D2Api, D2UserSchema, MetadataResponse, SelectedPick } from "../../types/d2-api";
 import _ from "lodash";
 import { Future, FutureData } from "../../domain/entities/Future";
 import { OrgUnit } from "../../domain/entities/OrgUnit";

--- a/src/data/utils.ts
+++ b/src/data/utils.ts
@@ -1,4 +1,4 @@
-import { MetadataResponse } from "@eyeseetea/d2-api/api";
+import { MetadataResponse } from "../types/d2-api";
 import _ from "lodash";
 import { Future, FutureData } from "../domain/entities/Future";
 import { Id } from "../domain/entities/Ref";

--- a/src/domain/repositories/UserRepository.ts
+++ b/src/domain/repositories/UserRepository.ts
@@ -1,4 +1,4 @@
-import { MetadataResponse } from "@eyeseetea/d2-api/2.36";
+import { MetadataResponse } from "../../types/d2-api";
 import { FutureData } from "../entities/Future";
 import { PaginatedResponse } from "../entities/PaginatedResponse";
 import { NamedRef } from "../entities/Ref";

--- a/src/domain/usecases/ListMetadataUseCase.ts
+++ b/src/domain/usecases/ListMetadataUseCase.ts
@@ -1,5 +1,5 @@
 import { UseCase } from "../../CompositionRoot";
-import { Pager } from "@eyeseetea/d2-api/2.36";
+import { Pager } from "../../types/d2-api";
 import { FutureData } from "../entities/Future";
 import { Metadata, MetadataType } from "../entities/Metadata";
 import { ListOptions, MetadataRepository } from "../repositories/MetadataRepository";

--- a/src/domain/usecases/SaveUsersUseCase.ts
+++ b/src/domain/usecases/SaveUsersUseCase.ts
@@ -4,7 +4,7 @@ import { Future, FutureData } from "../entities/Future";
 import { User } from "../entities/User";
 import { UserLogic } from "../entities/UserLogic";
 import { UserRepository } from "../repositories/UserRepository";
-import { MetadataResponse } from "@eyeseetea/d2-api/2.36";
+import { MetadataResponse } from "../../types/d2-api";
 
 export class SaveUsersUseCase implements UseCase {
     constructor(private userRepository: UserRepository) {}

--- a/src/domain/usecases/__tests__/CopyInUserUseCase.spec.ts
+++ b/src/domain/usecases/__tests__/CopyInUserUseCase.spec.ts
@@ -5,7 +5,7 @@ import { mock, instance, when, verify, anything, deepEqual } from "ts-mockito";
 import { UserD2ApiRepository } from "../../../data/repositories/UserD2ApiRepository";
 import { sourceUser, targetUser } from "./data/user";
 import { Future } from "../../entities/Future";
-import { MetadataResponse } from "@eyeseetea/d2-api/api";
+import { MetadataResponse } from "../../../types/d2-api";
 
 let userRepositoryMock: UserD2ApiRepository;
 let copyInUserUseCase: CopyInUserUseCase;

--- a/src/domain/usecases/__tests__/SaveUserOrgUnitUseCase.spec.ts
+++ b/src/domain/usecases/__tests__/SaveUserOrgUnitUseCase.spec.ts
@@ -4,7 +4,7 @@ import { OrgUnit } from "../../entities/OrgUnit";
 import { Future } from "../../entities/Future";
 import { anything, deepEqual, instance, mock, when, verify } from "ts-mockito";
 import _ from "lodash";
-import { MetadataResponse } from "@eyeseetea/d2-api/api";
+import { MetadataResponse } from "../../../types/d2-api";
 import { UserD2ApiRepository } from "../../../data/repositories/UserD2ApiRepository";
 import { sourceUser, targetUser } from "./data/user";
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,7 +7,7 @@ import _ from "lodash";
 import ReactDOM from "react-dom";
 import { Instance } from "./data/entities/Instance";
 import { D2Api } from "./types/d2-api";
-import { getD2APiFromInstance } from "./utils/d2-api";
+import { getD2ApiFromInstance } from "./utils/d2-api";
 import { App } from "./webapp/pages/app/App";
 import "./webapp/utils/wdyr";
 
@@ -67,7 +67,7 @@ async function main() {
         });
 
         const instance = new Instance({ url: baseUrl });
-        const api = getD2APiFromInstance(instance);
+        const api = getD2ApiFromInstance(instance);
         if (isDev) window.api = api;
 
         const userSettings = await api.get<{ keyUiLocale: string }>("/userSettings").getData();

--- a/src/types/d2-api.ts
+++ b/src/types/d2-api.ts
@@ -1,5 +1,9 @@
 import { D2Api } from "@eyeseetea/d2-api/2.41";
 import { getMockApiFromClass } from "@eyeseetea/d2-api";
+export type { TeiGetRequest } from "@eyeseetea/d2-api/api/trackedEntityInstances";
+export type { PatchOperation } from "@eyeseetea/d2-api/api/patch";
+export type { ErrorReport } from "@eyeseetea/d2-api/api/common";
+export type { CancelableResponse } from "@eyeseetea/d2-api/repositories/CancelableResponse";
 
 export * from "@eyeseetea/d2-api/2.41";
 export const getMockApi = getMockApiFromClass(D2Api);

--- a/src/types/d2-api.ts
+++ b/src/types/d2-api.ts
@@ -1,5 +1,5 @@
-import { D2Api } from "@eyeseetea/d2-api/2.36";
+import { D2Api } from "@eyeseetea/d2-api/2.41";
 import { getMockApiFromClass } from "@eyeseetea/d2-api";
 
-export * from "@eyeseetea/d2-api/2.36";
+export * from "@eyeseetea/d2-api/2.41";
 export const getMockApi = getMockApiFromClass(D2Api);

--- a/src/utils/d2-api.ts
+++ b/src/utils/d2-api.ts
@@ -9,7 +9,7 @@ export function getMajorVersion(version: string): number {
     return Number(apiVersion);
 }
 
-export function getD2APiFromInstance(instance: Instance) {
+export function getD2ApiFromInstance(instance: Instance) {
     return new D2Api({ baseUrl: instance.url, auth: instance.auth, backend: "fetch" });
 }
 

--- a/src/utils/futures.ts
+++ b/src/utils/futures.ts
@@ -1,4 +1,4 @@
-import { CancelableResponse } from "@eyeseetea/d2-api/repositories/CancelableResponse";
+import { CancelableResponse } from "../types/d2-api";
 import { Future, FutureData } from "../domain/entities/Future";
 
 export function apiToFuture<Data>(res: CancelableResponse<Data>): FutureData<Data> {

--- a/src/utils/tests.tsx
+++ b/src/utils/tests.tsx
@@ -8,13 +8,49 @@ import { Instance } from "../data/entities/Instance";
 import { User } from "../domain/entities/User";
 
 export function getTestUser(): User {
-    // @ts-ignore TODO
     return {
         id: "xE7jOejl9FI",
         name: "John Traore",
         username: "admin",
         userGroups: [],
         userRoles: [],
+        organisationUnits: [],
+        dataViewOrganisationUnits: [],
+        searchOrganisationsUnits: [],
+        firstName: "John",
+        surname: "Traore",
+        email: "john.traore@example.com",
+        phoneNumber: "",
+        whatsApp: "",
+        facebookMessenger: "",
+        skype: "",
+        telegram: "",
+        twitter: "",
+        lastUpdated: new Date("2020-01-01T12:00:00.000"),
+        created: new Date("2020-01-01T12:00:00.000"),
+        apiUrl: "http://localhost:8080/api",
+        lastLogin: new Date("2020-01-01T12:00:00.000"),
+        status: "ACTIVE",
+        disabled: false,
+        access: {
+            manage: true,
+            externalize: true,
+            write: true,
+            delete: true,
+            read: true,
+            update: true,
+        },
+        openId: null,
+        ldapId: null,
+        externalAuth: false,
+        twoFactorEnabled: false,
+        password: "",
+        accountExpiry: null,
+        authorities: ["ALL"],
+        createdBy: null,
+        lastModifiedBy: null,
+        uiLocale: "en",
+        dbLocale: "en",
     };
 }
 

--- a/src/webapp/components/user-form/components/UserRoleGroupFF.tsx
+++ b/src/webapp/components/user-form/components/UserRoleGroupFF.tsx
@@ -4,7 +4,7 @@ import { NamedRef } from "../../../../domain/entities/Ref";
 import { useAppContext } from "../../../contexts/app-context";
 import { useFuture } from "../../../hooks/useFuture";
 import { TransferFF, TransferFFProps } from "../../form/fields/TransferFF";
-import { D2ModelSchemas } from "@eyeseetea/d2-api/2.36";
+import { D2ModelSchemas } from "../../../../types/d2-api";
 
 export interface UserRoleGroupFFProps extends TransferFFProps {
     modelType: keyof D2ModelSchemas;

--- a/src/webapp/pages/user-bulk-edit/UserBulkEditPage.tsx
+++ b/src/webapp/pages/user-bulk-edit/UserBulkEditPage.tsx
@@ -1,5 +1,5 @@
 import { Button, ButtonStrip, CenteredContent, NoticeBox } from "@dhis2/ui";
-import { MetadataResponse } from "@eyeseetea/d2-api/2.36";
+import { MetadataResponse } from "../../../types/d2-api";
 import { useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
 import { Paper } from "@material-ui/core";
 import { Delete, ViewColumn } from "@material-ui/icons";


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes #869a4umgc [Add schemas for version 41 and test User-Extended App with the new version](https://app.clickup.com/t/869a4umgc)

### :memo: Implementation

- [x] point to 2.41 schemas
- [x]  fix errors when pointing to v2.41

### :video_camera: Screenshots/Screen capture

### :fire: Testing

It needs new version of d2-api: https://github.com/EyeSeeTea/d2-api/pull/178

To test it:

Go to that branch of d2-api:
```shell
yarn install
yarn build
cd build
yarn link
```

On this app:

```shell
yarn link "@eyeseetea/d2-api"
```
