### PR TITLE
fix: reduce concurrency to avoid deadlocks

### DIFF
--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -319,10 +319,10 @@ export class UserD2ApiRepository implements UserRepository {
                 logger?.log({ users: buildUserWithoutPassword(usersToSend as ApiUser[]) });
                 return apiToFuture(this.api.metadata.post({ users: usersToSend }))
                     .flatMap(data => {
-                        return Future.joinObj({
-                            saveLocales: this.saveLocales(usersToSave),
-                            saveGroupsStats: this.updateUserGroups(users, existingUsers, logger),
-                        }).map(() => {
+                        return Future.sequential([
+                            this.updateUserGroups(users, existingUsers, logger),
+                            this.saveLocales(usersToSave),
+                        ]).map(() => {
                             logger?.log(data);
                             return data;
                         });
@@ -494,7 +494,7 @@ export class UserD2ApiRepository implements UserRepository {
             return this.buildGroupsToSave(userGroup, action);
         });
 
-        return Future.parallel($requests, { maxConcurrency: 5 }).map(() => undefined);
+        return Future.sequential($requests).toVoid();
     }
 
     private buildUsersByGroupId(users: ApiUser[]): D2UserGroupByKey {


### PR DESCRIPTION

### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8699r8t7c

### :memo: Implementation

- Reduce api requests concurrency to avoid deadlocks on the server
  - This happened in specific environments only (dev)
  - These requests might end up locking each other (update userinfo locks + userinfo locks from FK update usersetting)
- The process will take more time but should be safer

### :video_camera: Screenshots/Screen capture

### :fire: Testing
