### PR TITLE
remove password validation when updating roles or groups

### DIFF
--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -392,7 +392,7 @@ export class UserD2ApiRepository implements UserRepository {
             );
 
             const users = storedUsers.map(user => {
-                const userResult = User.createNew({
+                const userResult = User.createExisted({
                     ...user,
                     userRoles:
                         strategy === "merge"
@@ -429,7 +429,7 @@ export class UserD2ApiRepository implements UserRepository {
             );
 
             const users = storedUsers.map(user => {
-                const userResult = User.createNew({
+                const userResult = User.createExisted({
                     ...user,
                     userGroups:
                         strategy === "merge"

--- a/src/domain/usecases/SaveUsersUseCase.ts
+++ b/src/domain/usecases/SaveUsersUseCase.ts
@@ -14,7 +14,7 @@ export class SaveUsersUseCase implements UseCase {
         if (!isUniqueOpenId(usersToSave)) return Future.error(i18n.t("Open IDs must be unique"));
 
         try {
-            const users = usersToSave.map(userProps => User.createNew(userProps).getOrThrow());
+            const users = usersToSave.map(userProps => User.createExisted(userProps).getOrThrow());
             return this.userRepository.save(users);
         } catch (error) {
             return Future.error(i18n.t((error as Error).message));


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869bhh9n8

### :memo: Implementation

We have a new entity `User.ts` and in order to create instances of this `user` we have 2 methods: one for new users and the other for existing ones. The difference is that for new users the password is mandatory.

This validation was throwing an error when updating roles or groups, I've changed it to use the validation for existing users instead.

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/08f3b2ef-ddb5-413e-924c-0b6e00c44b2f

### :fire: Testing

#869bhh9n8