### PR TITLE
Refactor/improve performance copy in dialog

### DIFF
--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -1,12 +1,4 @@
-import {
-    D2Api,
-    D2UserSchema,
-    MetadataResponse,
-    SelectedPick,
-    PatchOperation,
-    ErrorReport,
-    Selector,
-} from "../../types/d2-api";
+import { D2Api, D2UserSchema, MetadataResponse, SelectedPick, PatchOperation, ErrorReport } from "../../types/d2-api";
 import _ from "lodash";
 import { Future, FutureData } from "../../domain/entities/Future";
 import { OrgUnit } from "../../domain/entities/OrgUnit";

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -1,4 +1,12 @@
-import { D2Api, D2UserSchema, MetadataResponse, SelectedPick, PatchOperation, ErrorReport } from "../../types/d2-api";
+import {
+    D2Api,
+    D2UserSchema,
+    MetadataResponse,
+    SelectedPick,
+    PatchOperation,
+    ErrorReport,
+    Selector,
+} from "../../types/d2-api";
 import _ from "lodash";
 import { Future, FutureData } from "../../domain/entities/Future";
 import { OrgUnit } from "../../domain/entities/OrgUnit";
@@ -154,7 +162,7 @@ export class UserD2ApiRepository implements UserRepository {
                     })
                 ).flatMap(({ objects, pager }) => {
                     return this.recalculatePagination(options).map(newPager => {
-                        const users = objects.map(user => this.toDomainUser(user));
+                        const users = objects.map(user => this.toDomainUser(user as ApiUserWithAudit));
                         const excludeHiddenUsers = usersIdsToHide
                             ? users.filter(user => !usersIdsToHide.includes(user.id))
                             : users;
@@ -312,7 +320,7 @@ export class UserD2ApiRepository implements UserRepository {
             if (!idFilterValues || idFilterValues.length === 0) {
                 return apiToFuture(
                     this.api.models.users.get({
-                        fields: { id: true, userCredentials: { username: true } },
+                        fields: { id: true, name: true, userCredentials: { username: true } },
                         paging: false,
                         ...this.createCommonListQueryParams(options),
                     })
@@ -321,7 +329,12 @@ export class UserD2ApiRepository implements UserRepository {
                         ? objects.filter(user => !usersIdsToExclude.includes(user.id))
                         : objects;
                     return filteredObjects.map(
-                        user => new UserIdentifier({ id: user.id, username: user.userCredentials.username })
+                        user =>
+                            new UserIdentifier({
+                                id: user.id,
+                                username: user.userCredentials.username,
+                                name: user.name,
+                            })
                     );
                 });
             }
@@ -355,7 +368,7 @@ export class UserD2ApiRepository implements UserRepository {
 
                 return apiToFuture(
                     this.api.models.users.get({
-                        fields: { id: true, userCredentials: { username: true } },
+                        fields: { id: true, name: true, userCredentials: { username: true } },
                         paging: false,
                         ...this.createCommonListQueryParams(chunkOptions),
                     })
@@ -369,7 +382,7 @@ export class UserD2ApiRepository implements UserRepository {
                 : objects;
             const uniqueUsers = _.uniqBy(filteredObjects, user => user.id);
             return uniqueUsers.map(
-                user => new UserIdentifier({ id: user.id, username: user.userCredentials.username })
+                user => new UserIdentifier({ id: user.id, username: user.userCredentials.username, name: user.name })
             );
         });
     }
@@ -922,13 +935,15 @@ export class UserD2ApiRepository implements UserRepository {
     public getInMyOrgUnit(): FutureData<UserIdentifier[]> {
         return apiToFuture(
             this.api.models.users.get({
-                fields: { id: true, displayName: true },
+                fields: { id: true, displayName: true, name: true },
                 paging: false,
                 userOrgUnits: "true",
                 includeChildren: "true",
             })
         ).map(({ objects }) => {
-            return objects.map(user => new UserIdentifier({ id: user.id, username: user.displayName }));
+            return objects.map(
+                user => new UserIdentifier({ id: user.id, username: user.displayName, name: user.name })
+            );
         });
     }
 

--- a/src/domain/entities/UserIdentifier.ts
+++ b/src/domain/entities/UserIdentifier.ts
@@ -3,14 +3,17 @@ import { Id } from "./Ref";
 export interface UserIdentifierProps {
     id: Id;
     username: string;
+    name: string;
 }
 
 export class UserIdentifier {
     public readonly id: Id;
     public readonly username: string;
+    public readonly name: string;
 
     constructor(props: UserIdentifierProps) {
         this.id = props.id;
         this.username = props.username;
+        this.name = props.name;
     }
 }

--- a/src/webapp/components/copy-in-user-dialog/CopyInUserDialog.tsx
+++ b/src/webapp/components/copy-in-user-dialog/CopyInUserDialog.tsx
@@ -9,6 +9,7 @@ import { Box } from "@material-ui/core";
 import styled from "styled-components";
 import { SegmentedControl, Transfer } from "@dhis2/ui";
 import { ConfirmationDialog, useSnackbar } from "@eyeseetea/d2-ui-components";
+import { UserIdentifier } from "../../../domain/entities/UserIdentifier";
 
 export const CopyInUserDialog: React.FC<CopyInUserDialogProps> = props => {
     const { onCancel, onSave, user, visible, usersList } = props;
@@ -132,7 +133,7 @@ export type CopyInUserDialogProps = {
     onSave: (selectedUsersIds: Id[], updateStrategy: UpdateStrategy, accessElements: AccessElements) => void;
     user: UserProps;
     visible: boolean;
-    usersList: UserProps[];
+    usersList: UserIdentifier[];
 };
 
 const Container = styled.div`

--- a/src/webapp/components/user-list-table/UserListTable.tsx
+++ b/src/webapp/components/user-list-table/UserListTable.tsx
@@ -29,7 +29,6 @@ import {
     useColumnsPreferences,
     useCopyInUser,
     useGetAllUserIdentifiers,
-    useGetAllUsers,
     useGetUsersByIds,
     useSaveUsersOrgUnits,
 } from "../../hooks/userHooks";

--- a/src/webapp/components/user-list-table/UserListTable.tsx
+++ b/src/webapp/components/user-list-table/UserListTable.tsx
@@ -28,6 +28,7 @@ import { useReload } from "../../hooks/useReload";
 import {
     useColumnsPreferences,
     useCopyInUser,
+    useGetAllUserIdentifiers,
     useGetAllUsers,
     useGetUsersByIds,
     useSaveUsersOrgUnits,
@@ -136,7 +137,7 @@ export const UserListTable: React.FC<UserListTableProps> = ({
     const userColumns = useUserColumns();
 
     const { users, setUsers } = useGetUsersByIds(selectedUserIds);
-    const { users: allUsers } = useGetAllUsers(onlyUsersOrgUnits);
+    const { userIdentifiers: allUsers } = useGetAllUserIdentifiers(onlyUsersOrgUnits);
     const { appSettings } = useAppSettingsContext();
     const {
         showOnlyActiveUsers: onlyActiveUsers,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869c14d0d #869c14d0d

### :memo: Implementation

- [x] Improve performance to open copy in dialog

The problem was retrieve all users with a lot of unnecessary fields page by page

Now only necessary fields are retrieved with id, name, username y a single request.

### :video_camera: Screenshots/Screen capture

https://github.com/user-attachments/assets/24a7eb83-0a59-4073-ac0b-0e5e9a0b89fa

### :fire: Testing
