### PR TITLE
refactor: support 2.42 en userRepository and UserModel

### DIFF
--- a/src/data/models/UserModel.ts
+++ b/src/data/models/UserModel.ts
@@ -15,6 +15,10 @@ export const AccessPermissionsModel: Codec<AccessPermissions> = Schema.object({
 export const ApiUserModel: Codec<ApiUser> = Schema.object({
     id: Schema.string,
     name: Schema.string,
+    username: Schema.optionalSafe(Schema.string, ""),
+    lastLogin: Schema.optionalSafe(Schema.string, ""),
+    disabled: Schema.optionalSafe(Schema.boolean, false),
+    externalAuth: Schema.optionalSafe(Schema.boolean, false),
     firstName: Schema.string,
     surname: Schema.string,
     email: Schema.optionalSafe(Schema.string, ""),
@@ -31,6 +35,16 @@ export const ApiUserModel: Codec<ApiUser> = Schema.object({
     dataViewOrganisationUnits: Schema.array(OrgUnitModel),
     teiSearchOrganisationUnits: Schema.array(OrgUnitModel),
     access: AccessPermissionsModel,
+    userRoles: Schema.optionalSafe(
+        Schema.array(
+            Schema.object({
+                id: Schema.string,
+                name: Schema.string,
+                authorities: Schema.optionalSafe(Schema.array(Schema.string), []),
+            })
+        ),
+        []
+    ),
     userCredentials: Schema.object({
         id: Schema.string,
         username: Schema.string,

--- a/src/data/models/UserModel.ts
+++ b/src/data/models/UserModel.ts
@@ -16,6 +16,8 @@ export const ApiUserModel: Codec<ApiUser> = Schema.object({
     id: Schema.string,
     name: Schema.string,
     username: Schema.optionalSafe(Schema.string, ""),
+    openId: Schema.optionalSafe(Schema.string, ""),
+    ldapId: Schema.optionalSafe(Schema.string, ""),
     lastLogin: Schema.optionalSafe(Schema.string, ""),
     disabled: Schema.optionalSafe(Schema.boolean, false),
     externalAuth: Schema.optionalSafe(Schema.boolean, false),

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -605,8 +605,13 @@ export class UserD2ApiRepository implements UserRepository {
 
     private buildUsersToSave(existingUser: Maybe<ApiUser>, user: ApiUser) {
         const shouldSendPassword = Boolean(user.userCredentials.password);
-        const shouldSendOpenId = user.userCredentials.openId !== undefined && user.userCredentials.openId !== "";
-        const shouldSendLdapId = user.userCredentials.ldapId !== undefined && user.userCredentials.ldapId !== "";
+        const rootOpenId = user.openId;
+        const rootLdapId = user.ldapId;
+        const effectiveOpenId = rootOpenId ?? user.userCredentials.openId;
+        const effectiveLdapId = rootLdapId ?? user.userCredentials.ldapId;
+
+        const shouldSendOpenId = effectiveOpenId !== undefined && effectiveOpenId !== "";
+        const shouldSendLdapId = effectiveLdapId !== undefined && effectiveLdapId !== "";
         const shouldSendAccountExpiry =
             user.userCredentials.accountExpiry !== undefined && user.userCredentials.accountExpiry !== "";
         const shouldSendTwoFA = user.userCredentials.twoFA === true;
@@ -618,14 +623,15 @@ export class UserD2ApiRepository implements UserRepository {
             userRoles: user.userRoles,
             username: user.username,
             disabled: user.disabled ?? user.userCredentials.disabled,
-            ...(shouldSendOpenId ? { openId: user.userCredentials.openId } : {}),
+            ...(shouldSendOpenId ? { openId: effectiveOpenId } : {}),
+            ...(shouldSendLdapId ? { ldapId: effectiveLdapId } : {}),
             ...(shouldSendPassword ? { password: user.userCredentials.password } : {}),
             userCredentials: {
                 ...(existingUser || {}).userCredentials,
                 ...user.userCredentials,
                 id: user.id,
-                ...(shouldSendOpenId ? { openId: user.userCredentials.openId } : {}),
-                ...(shouldSendLdapId ? { ldapId: user.userCredentials.ldapId } : {}),
+                ...(shouldSendOpenId ? { openId: effectiveOpenId } : {}),
+                ...(shouldSendLdapId ? { ldapId: effectiveLdapId } : {}),
                 ...(shouldSendPassword ? { password: user.userCredentials.password } : {}),
                 ...(shouldSendAccountExpiry ? { accountExpiry: user.userCredentials.accountExpiry } : {}),
                 ...(shouldSendTwoFA ? { twoFA: true } : {}),
@@ -833,6 +839,8 @@ export class UserD2ApiRepository implements UserRepository {
         const lastLoginRaw = input.lastLogin ?? userCredentials.lastLogin;
         const disabled: boolean = input.disabled ?? userCredentials.disabled ?? false;
         const externalAuth: boolean = input.externalAuth ?? userCredentials.externalAuth ?? false;
+        const ldapId = input.ldapId ?? userCredentials.ldapId;
+        const openId = input.openId ?? userCredentials.openId;
 
         const authorities = _(userRoles)
             .map(userRole => userRole.authorities ?? [])
@@ -871,8 +879,8 @@ export class UserD2ApiRepository implements UserRepository {
             dataViewOrganisationUnits: this.getDomainOrgUnits(user.dataViewOrganisationUnits),
             searchOrganisationsUnits: this.getDomainOrgUnits(user.teiSearchOrganisationUnits),
             access: user.access,
-            openId: userCredentials.openId,
-            ldapId: userCredentials.ldapId,
+            openId,
+            ldapId,
             externalAuth,
             twoFactorEnabled: userCredentials.twoFA,
             password: userCredentials.password,
@@ -908,6 +916,8 @@ export class UserD2ApiRepository implements UserRepository {
             id: input.id,
             name: input.name,
             username: input.username,
+            openId: input.openId ?? "",
+            ldapId: input.ldapId ?? "",
             firstName: input.firstName,
             surname: input.surname,
             email: input.email,
@@ -1088,6 +1098,8 @@ const fields = {
     lastLogin: true,
     disabled: true,
     externalAuth: true,
+    ldapId: true,
+    openId: true,
     userGroups: { id: true, name: true },
     organisationUnits: orgUnitsFields,
     dataViewOrganisationUnits: orgUnitsFields,

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -615,11 +615,18 @@ export class UserD2ApiRepository implements UserRepository {
         const shouldSendAccountExpiry =
             user.userCredentials.accountExpiry !== undefined && user.userCredentials.accountExpiry !== "";
         const shouldSendTwoFA = user.userCredentials.twoFA === true;
+        // Strip twoFA from the credentials spread so the shouldSendTwoFA guard below actually
+        // controls it — otherwise the spread would inject twoFA:false and disable 2FA on save.
+        const { twoFA: _stripTwoFA, ...userCredentialsWithoutTwoFA } = user.userCredentials;
 
         return {
             ...(existingUser || {}),
             ...user,
-            // include these fields here and in userCredentials due to a bug in v2.38
+            // Dual-write: send these fields both at root level (required by DHIS2 2.42+, where
+            // the userCredentials schema was removed) and inside userCredentials (required by
+            // ≤2.41, which also has a 2.38 bug where root-level alone is ignored). On 2.42 the
+            // userCredentials block is silently ignored by the server. See getIs242Plus() for
+            // the version detection used by filters and list fields.
             userRoles: user.userRoles,
             username: user.username,
             disabled: user.disabled ?? user.userCredentials.disabled,
@@ -628,7 +635,7 @@ export class UserD2ApiRepository implements UserRepository {
             ...(shouldSendPassword ? { password: user.userCredentials.password } : {}),
             userCredentials: {
                 ...(existingUser || {}).userCredentials,
-                ...user.userCredentials,
+                ...userCredentialsWithoutTwoFA,
                 id: user.id,
                 ...(shouldSendOpenId ? { openId: effectiveOpenId } : {}),
                 ...(shouldSendLdapId ? { ldapId: effectiveLdapId } : {}),

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -134,10 +134,17 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     public list(options: ListOptions): FutureData<PaginatedResponse<User>> {
+        return this.translateListFiltersForApi(options.filters).flatMap(({ is242Plus, filters }) => {
+            return this.listWithVersion({ ...options, filters }, is242Plus);
+        });
+    }
+
+    private listWithVersion(options: ListOptions, is242Plus: boolean): FutureData<PaginatedResponse<User>> {
         const { page, pageSize, filters } = options;
         const normalizedPage = page ?? 1;
         const normalizedPageSize = pageSize ?? 25;
         const idFilterValues = this.getIdInFilterValues(options);
+        const translatedFilters = filters;
 
         return this.getUsersIdsInChunks(options.hideUsers).flatMap(usersIdsToHide => {
             if (!idFilterValues || idFilterValues.length === 0) {
@@ -150,7 +157,7 @@ export class UserD2ApiRepository implements UserRepository {
                         },
                         page,
                         pageSize,
-                        ...this.createCommonListQueryParams(options),
+                        ...this.createCommonListQueryParams({ ...options, filters: translatedFilters }, is242Plus),
                     })
                 ).flatMap(({ objects, pager }) => {
                     return this.recalculatePagination(options).map(newPager => {
@@ -164,9 +171,8 @@ export class UserD2ApiRepository implements UserRepository {
             }
 
             // If there is an ID filter, we need to chunk the requests to avoid URL length limits
-            //
             const sorting = options.sorting ?? { field: "firstName", order: "asc" };
-            const baseFilters = filters ?? {};
+            const baseFilters = translatedFilters ?? {};
 
             return chunkRequest(
                 idFilterValues,
@@ -187,7 +193,7 @@ export class UserD2ApiRepository implements UserRepository {
                                 userCredentials: { ...fields.userCredentials, ...auditFields },
                             },
                             paging: false,
-                            ...this.createCommonListQueryParams(chunkOptions),
+                            ...this.createCommonListQueryParams(chunkOptions, is242Plus),
                         })
                     ).map(({ objects }) => objects);
                 },
@@ -237,15 +243,15 @@ export class UserD2ApiRepository implements UserRepository {
 
     private buildFilters(
         filters: ListFilters | undefined,
-        override: { onlyActiveUsers: boolean }
+        override: { onlyActiveUsers: boolean },
+        is242Plus: boolean
     ): Record<string, Record<string, string[]> | undefined> {
         const otherFilters = _.mapValues(filters, items => (items ? { [items[0]]: items[1] } : undefined));
+        const disabledKey = is242Plus ? "disabled" : "userCredentials.disabled";
 
         return {
             ...otherFilters,
-            "userCredentials.disabled": override.onlyActiveUsers
-                ? { eq: ["false"] }
-                : otherFilters["userCredentials.disabled"],
+            [disabledKey]: override.onlyActiveUsers ? { eq: ["false"] } : otherFilters[disabledKey],
         };
     }
 
@@ -265,21 +271,23 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     public listAllIds(options: ListOptions): FutureData<string[]> {
-        return this.getUsersIdsInChunks(options.hideUsers).flatMap(usersIdsToExclude => {
-            return apiToFuture(
-                this.api.models.users.get({
-                    fields: { id: true },
-                    paging: false,
-                    ...this.createCommonListQueryParams(options),
-                })
-            ).map(({ objects }) => {
-                const usersIds = objects.map(user => user.id);
-                return usersIdsToExclude ? usersIds.filter(id => !usersIdsToExclude.includes(id)) : usersIds;
+        return this.translateListFiltersForApi(options.filters).flatMap(({ is242Plus, filters }) => {
+            return this.getUsersIdsInChunks(options.hideUsers).flatMap(usersIdsToExclude => {
+                return apiToFuture(
+                    this.api.models.users.get({
+                        fields: { id: true },
+                        paging: false,
+                        ...this.createCommonListQueryParams({ ...options, filters }, is242Plus),
+                    })
+                ).map(({ objects }) => {
+                    const usersIds = objects.map(user => user.id);
+                    return usersIdsToExclude ? usersIds.filter(id => !usersIdsToExclude.includes(id)) : usersIds;
+                });
             });
         });
     }
 
-    private createCommonListQueryParams(options: ListOptions) {
+    private createCommonListQueryParams(options: ListOptions, is242Plus: boolean) {
         const {
             search,
             sorting = { field: "firstName", order: "asc" },
@@ -290,7 +298,7 @@ export class UserD2ApiRepository implements UserRepository {
             onlyUsersOrgUnits,
         } = options;
 
-        const otherFilters = this.buildFilters(filters, { onlyActiveUsers });
+        const otherFilters = this.buildFilters(filters, { onlyActiveUsers }, is242Plus);
         const areFiltersEnabled = _(otherFilters).values().some();
         const sortingField = sorting.field === "status" ? "disabled" : sorting.field;
 
@@ -306,7 +314,14 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     public listAllUserIdentifiers(options: ListOptions): FutureData<UserIdentifier[]> {
+        return this.translateListFiltersForApi(options.filters).flatMap(({ is242Plus, filters }) => {
+            return this.listAllUserIdentifiersWithVersion({ ...options, filters }, is242Plus);
+        });
+    }
+
+    private listAllUserIdentifiersWithVersion(options: ListOptions, is242Plus: boolean): FutureData<UserIdentifier[]> {
         const idFilterValues = this.getIdInFilterValues(options);
+        const translatedFilters = options.filters;
 
         return this.getUsersIdsInChunks(options.hideUsers).flatMap(usersIdsToExclude => {
             if (!idFilterValues || idFilterValues.length === 0) {
@@ -314,7 +329,7 @@ export class UserD2ApiRepository implements UserRepository {
                     this.api.models.users.get({
                         fields: { id: true, name: true, username: true, userCredentials: { username: true } },
                         paging: false,
-                        ...this.createCommonListQueryParams(options),
+                        ...this.createCommonListQueryParams({ ...options, filters: translatedFilters }, is242Plus),
                     })
                 ).map(({ objects }) => {
                     const filteredObjects = usersIdsToExclude
@@ -331,7 +346,7 @@ export class UserD2ApiRepository implements UserRepository {
                 });
             }
 
-            return this.getUserIdentifiersInChunks(options, {
+            return this.getUserIdentifiersInChunks({ ...options, filters: translatedFilters }, is242Plus, {
                 userIds: idFilterValues,
                 usersIdsToExclude: usersIdsToExclude,
             });
@@ -347,6 +362,7 @@ export class UserD2ApiRepository implements UserRepository {
 
     private getUserIdentifiersInChunks(
         options: ListOptions,
+        is242Plus: boolean,
         params: { userIds: Maybe<Id[]>; usersIdsToExclude: Maybe<Id[]> }
     ): FutureData<UserIdentifier[]> {
         const { userIds, usersIdsToExclude } = params;
@@ -362,7 +378,7 @@ export class UserD2ApiRepository implements UserRepository {
                     this.api.models.users.get({
                         fields: { id: true, name: true, username: true, userCredentials: { username: true } },
                         paging: false,
-                        ...this.createCommonListQueryParams(chunkOptions),
+                        ...this.createCommonListQueryParams(chunkOptions, is242Plus),
                     })
                 ).map(({ objects }) => objects);
             },
@@ -476,7 +492,8 @@ export class UserD2ApiRepository implements UserRepository {
             onlyActiveUsers,
         } = options;
 
-        const otherFilters = this.buildFilters(filters, { onlyActiveUsers });
+        // getFullUsers is only used internally for save() prefetch; keep legacy behavior (2.41 compatible)
+        const otherFilters = this.buildFilters(filters, { onlyActiveUsers }, false);
 
         const userData$ = apiToFuture(
             this.api.models.users.get({
@@ -1002,6 +1019,40 @@ export class UserD2ApiRepository implements UserRepository {
                     pageCount: Math.ceil(userIds.length / (options.pageSize ?? 25)),
                 };
             });
+        });
+    }
+
+    @cache()
+    private getIs242Plus(): FutureData<boolean> {
+        return Future.fromPromise(this.api.getVersion()).map(version => getMajorVersion(version) >= 42);
+    }
+
+    private translateListFiltersForApi(
+        filters: ListFilters | undefined
+    ): FutureData<{ is242Plus: boolean; filters: ListFilters | undefined }> {
+        return this.getIs242Plus().map(is242Plus => {
+            if (!filters) return { is242Plus, filters };
+            if (!is242Plus) return { is242Plus, filters };
+
+            const prefix = "userCredentials.";
+            const rootWhitelist = new Set(["username", "disabled", "externalAuth", "lastLogin", "userRoles.id"]);
+
+            const translated = _(filters)
+                .toPairs()
+                .flatMap(([key, value]) => {
+                    if (!key.startsWith(prefix)) return [[key, value] as const];
+
+                    const candidate = key.slice(prefix.length);
+                    // In DHIS2 2.42, filters using userCredentials.* can fail. Only translate the keys
+                    // we know exist in the root user schema; drop the rest (e.g. twoFA).
+                    if (!rootWhitelist.has(candidate)) return [];
+
+                    return [[candidate, value] as const];
+                })
+                .fromPairs()
+                .value();
+
+            return { is242Plus, filters: translated };
         });
     }
 }

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -312,7 +312,7 @@ export class UserD2ApiRepository implements UserRepository {
             if (!idFilterValues || idFilterValues.length === 0) {
                 return apiToFuture(
                     this.api.models.users.get({
-                        fields: { id: true, name: true, userCredentials: { username: true } },
+                        fields: { id: true, name: true, username: true, userCredentials: { username: true } },
                         paging: false,
                         ...this.createCommonListQueryParams(options),
                     })
@@ -324,7 +324,7 @@ export class UserD2ApiRepository implements UserRepository {
                         user =>
                             new UserIdentifier({
                                 id: user.id,
-                                username: user.userCredentials.username,
+                                username: user.username ?? user.userCredentials.username,
                                 name: user.name,
                             })
                     );
@@ -360,7 +360,7 @@ export class UserD2ApiRepository implements UserRepository {
 
                 return apiToFuture(
                     this.api.models.users.get({
-                        fields: { id: true, name: true, userCredentials: { username: true } },
+                        fields: { id: true, name: true, username: true, userCredentials: { username: true } },
                         paging: false,
                         ...this.createCommonListQueryParams(chunkOptions),
                     })
@@ -374,7 +374,12 @@ export class UserD2ApiRepository implements UserRepository {
                 : objects;
             const uniqueUsers = _.uniqBy(filteredObjects, user => user.id);
             return uniqueUsers.map(
-                user => new UserIdentifier({ id: user.id, username: user.userCredentials.username, name: user.name })
+                user =>
+                    new UserIdentifier({
+                        id: user.id,
+                        username: user.username || user.userCredentials.username,
+                        name: user.name,
+                    })
             );
         });
     }
@@ -582,20 +587,31 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     private buildUsersToSave(existingUser: Maybe<ApiUser>, user: ApiUser) {
+        const shouldSendPassword = Boolean(user.userCredentials.password);
+        const shouldSendOpenId = user.userCredentials.openId !== undefined && user.userCredentials.openId !== "";
+        const shouldSendLdapId = user.userCredentials.ldapId !== undefined && user.userCredentials.ldapId !== "";
+        const shouldSendAccountExpiry =
+            user.userCredentials.accountExpiry !== undefined && user.userCredentials.accountExpiry !== "";
+        const shouldSendTwoFA = user.userCredentials.twoFA === true;
+
         return {
             ...(existingUser || {}),
             ...user,
             // include these fields here and in userCredentials due to a bug in v2.38
-            userRoles: user.userCredentials.userRoles,
-            username: user.userCredentials.username,
-            disabled: user.userCredentials.disabled,
-            openId: user.userCredentials.openId,
-            password: user.userCredentials.password,
+            userRoles: user.userRoles,
+            username: user.username,
+            disabled: user.disabled ?? user.userCredentials.disabled,
+            ...(shouldSendOpenId ? { openId: user.userCredentials.openId } : {}),
+            ...(shouldSendPassword ? { password: user.userCredentials.password } : {}),
             userCredentials: {
                 ...(existingUser || {}).userCredentials,
                 ...user.userCredentials,
                 id: user.id,
-                accountExpiry: user.userCredentials.accountExpiry ? user.userCredentials.accountExpiry : undefined,
+                ...(shouldSendOpenId ? { openId: user.userCredentials.openId } : {}),
+                ...(shouldSendLdapId ? { ldapId: user.userCredentials.ldapId } : {}),
+                ...(shouldSendPassword ? { password: user.userCredentials.password } : {}),
+                ...(shouldSendAccountExpiry ? { accountExpiry: user.userCredentials.accountExpiry } : {}),
+                ...(shouldSendTwoFA ? { twoFA: true } : {}),
             },
         };
     }
@@ -790,9 +806,19 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     private toDomainUser(input: ApiUserWithAudit): User {
-        const { userCredentials, ...user } = input;
-        const authorities = _(userCredentials.userRoles)
-            .map(userRole => userRole.authorities)
+        const { userCredentials: rawUserCredentials, ...user } = input;
+
+        const userCredentials = rawUserCredentials ?? {};
+
+        const userRoles = input.userRoles || userCredentials.userRoles || [];
+        const username = input.username || userCredentials.username || "";
+
+        const lastLoginRaw = input.lastLogin ?? userCredentials.lastLogin;
+        const disabled: boolean = input.disabled ?? userCredentials.disabled ?? false;
+        const externalAuth: boolean = input.externalAuth ?? userCredentials.externalAuth ?? false;
+
+        const authorities = _(userRoles)
+            .map(userRole => userRole.authorities ?? [])
             .flatten()
             .uniq()
             .value();
@@ -814,23 +840,23 @@ export class UserD2ApiRepository implements UserRepository {
             userGroups: _(user.userGroups)
                 .orderBy(ug => ug.name)
                 .value(),
-            username: userCredentials.username,
+            username,
             apiUrl: `${this.api.baseUrl}/api/users/${user.id}.json`,
             userRoles:
-                _(userCredentials.userRoles)
+                _(userRoles)
                     .map(userRole => ({ id: userRole.id, name: userRole.name }))
                     .orderBy(ur => ur.name)
                     .value() || [],
-            lastLogin: userCredentials.lastLogin ? new Date(userCredentials.lastLogin) : undefined,
-            status: userCredentials.disabled ? "Disabled" : "Active",
-            disabled: userCredentials.disabled,
+            lastLogin: lastLoginRaw ? new Date(lastLoginRaw) : undefined,
+            status: disabled ? "Disabled" : "Active",
+            disabled,
             organisationUnits: this.getDomainOrgUnits(user.organisationUnits),
             dataViewOrganisationUnits: this.getDomainOrgUnits(user.dataViewOrganisationUnits),
             searchOrganisationsUnits: this.getDomainOrgUnits(user.teiSearchOrganisationUnits),
             access: user.access,
             openId: userCredentials.openId,
             ldapId: userCredentials.ldapId,
-            externalAuth: userCredentials.externalAuth,
+            externalAuth,
             twoFactorEnabled: userCredentials.twoFA,
             password: userCredentials.password,
             accountExpiry: userCredentials.accountExpiry,
@@ -851,8 +877,9 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     private getUserAuditFields(user: ApiUserWithAudit): Pick<User, "createdBy" | "lastModifiedBy"> {
-        const createdBy = user.userCredentials.createdBy || user.createdBy;
-        const lastUpdatedBy = user.userCredentials.lastUpdatedBy || user.lastUpdatedBy;
+        const uc = user.userCredentials;
+        const createdBy = uc?.createdBy || user.createdBy;
+        const lastUpdatedBy = uc?.lastUpdatedBy || user.lastUpdatedBy;
         return {
             createdBy: createdBy ? { id: createdBy.id, username: createdBy.displayName } : undefined,
             lastModifiedBy: lastUpdatedBy ? { id: lastUpdatedBy?.id, username: lastUpdatedBy?.displayName } : undefined,
@@ -863,6 +890,7 @@ export class UserD2ApiRepository implements UserRepository {
         return {
             id: input.id,
             name: input.name,
+            username: input.username,
             firstName: input.firstName,
             surname: input.surname,
             email: input.email,
@@ -874,7 +902,12 @@ export class UserD2ApiRepository implements UserRepository {
             twitter: input.twitter,
             lastUpdated: input.lastUpdated.toISOString(),
             created: input.created.toISOString(),
+            // DHIS2 2.42 exposes these at root; keep populated for compatibility
+            lastLogin: input.lastLogin?.toISOString() ?? "",
+            disabled: input.disabled,
+            externalAuth: input.externalAuth ?? false,
             userGroups: input.userGroups,
+            userRoles: input.userRoles.map(userRole => ({ id: userRole.id, name: userRole.name, authorities: [] })),
             organisationUnits: this.getApiOrgUnits(input.organisationUnits),
             dataViewOrganisationUnits: this.getApiOrgUnits(input.dataViewOrganisationUnits),
             teiSearchOrganisationUnits: this.getApiOrgUnits(input.searchOrganisationsUnits),
@@ -988,6 +1021,7 @@ const auditFields = {
 const fields = {
     id: true,
     name: true,
+    username: true,
     firstName: true,
     surname: true,
     email: true,
@@ -999,10 +1033,15 @@ const fields = {
     twitter: true,
     lastUpdated: true,
     created: true,
+    // DHIS2 2.42 exposes some credentials fields at root
+    lastLogin: true,
+    disabled: true,
+    externalAuth: true,
     userGroups: { id: true, name: true },
     organisationUnits: orgUnitsFields,
     dataViewOrganisationUnits: orgUnitsFields,
     teiSearchOrganisationUnits: orgUnitsFields,
+    userRoles: { id: true, name: true, authorities: true },
     access: {
         manage: true,
         externalize: true,
@@ -1039,7 +1078,7 @@ const ownerFields = {
     invitation: true,
     disabled: true,
     attributeValues: true,
-    userRoles: { id: true },
+    userRoles: { id: true, name: true, authorities: true },
 } as const;
 
 export type ApiUser = SelectedPick<D2UserSchema, typeof fields>;

--- a/src/legacy/List/Filters.component.js
+++ b/src/legacy/List/Filters.component.js
@@ -180,15 +180,26 @@ export default class Filters extends React.Component {
 
         const inFilter = field => (_(field).isEmpty() ? null : ["in", field]);
 
+        const is242Plus = (() => {
+            const version = this.context?.d2?.system?.systemInfo?.version;
+            const minor = version ? Number(String(version).split(".")[1]) : undefined;
+            return minor !== undefined && !Number.isNaN(minor) && minor >= 42;
+        })();
+
         return {
             ...(showOnlyManagedUsers ? { canManage: "true" } : {}),
             ...(searchString ? { query: searchString } : {}),
             ...(rootJunction ? { rootJunction } : {}),
             filters: {
-                "userCredentials.disabled": userDisabled !== null ? ["eq", userDisabled] : undefined,
-                "userCredentials.twoFA": twoFactorEnabled !== null ? ["eq", twoFactorEnabled] : undefined,
-                "userCredentials.externalAuth": externalAuth !== null ? ["eq", externalAuth] : undefined,
-                "userCredentials.userRoles.id": inFilter(userRoles),
+                [is242Plus ? "disabled" : "userCredentials.disabled"]:
+                    userDisabled !== null ? ["eq", userDisabled] : undefined,
+                // DHIS2 2.42 removed twoFA from userCredentials responses for security
+                ...(is242Plus
+                    ? {}
+                    : { "userCredentials.twoFA": twoFactorEnabled !== null ? ["eq", twoFactorEnabled] : undefined }),
+                [is242Plus ? "externalAuth" : "userCredentials.externalAuth"]:
+                    externalAuth !== null ? ["eq", externalAuth] : undefined,
+                [is242Plus ? "userRoles.id" : "userCredentials.userRoles.id"]: inFilter(userRoles),
                 "userGroups.id": inFilter(userGroups),
                 "organisationUnits.id": inFilter(orgUnits.map(ou => ou.id)),
                 "dataViewOrganisationUnits.id": inFilter(orgUnitsOutput.map(ou => ou.id)),

--- a/src/legacy/List/Filters.component.js
+++ b/src/legacy/List/Filters.component.js
@@ -163,6 +163,13 @@ export default class Filters extends React.Component {
         );
     };
 
+    /** DHIS2 2.42+ (minor >= 42): API / user list shape changes (e.g. twoFA no longer on userCredentials). */
+    getIs242Plus = () => {
+        const version = this.context?.d2?.system?.systemInfo?.version;
+        const minor = version ? Number(String(version).split(".")[1]) : undefined;
+        return minor !== undefined && !Number.isNaN(minor) && minor >= 42;
+    };
+
     getFilterOptions = () => {
         const {
             showOnlyManagedUsers,
@@ -180,11 +187,7 @@ export default class Filters extends React.Component {
 
         const inFilter = field => (_(field).isEmpty() ? null : ["in", field]);
 
-        const is242Plus = (() => {
-            const version = this.context?.d2?.system?.systemInfo?.version;
-            const minor = version ? Number(String(version).split(".")[1]) : undefined;
-            return minor !== undefined && !Number.isNaN(minor) && minor >= 42;
-        })();
+        const is242Plus = this.getIs242Plus();
 
         return {
             ...(showOnlyManagedUsers ? { canManage: "true" } : {}),
@@ -284,6 +287,7 @@ export default class Filters extends React.Component {
             this.props;
 
         const { styles } = this;
+        const is242Plus = this.getIs242Plus();
 
         const isExtendedFiltering =
             showOnlyManagedUsers ||
@@ -408,17 +412,18 @@ export default class Filters extends React.Component {
                                 </div>
                             )}
 
-                            {(isSuperAdmin || appSettings.uiUserActionsAccess.filterTwoFactorAuth.visible) && (
-                                <div className="user-management-control select-active-or-inactive">
-                                    <Dropdown
-                                        labelText={this.getTranslation("filter_2fa_status")}
-                                        options={enabledDisabledOptions}
-                                        value={this.state.twoFactorEnabled}
-                                        onChange={this.setFilter("twoFactorEnabled", this.dropdownHandler)}
-                                        style={styles.dropdownStyles}
-                                    />
-                                </div>
-                            )}
+                            {!is242Plus &&
+                                (isSuperAdmin || appSettings.uiUserActionsAccess.filterTwoFactorAuth.visible) && (
+                                    <div className="user-management-control select-active-or-inactive">
+                                        <Dropdown
+                                            labelText={this.getTranslation("filter_2fa_status")}
+                                            options={enabledDisabledOptions}
+                                            value={this.state.twoFactorEnabled}
+                                            onChange={this.setFilter("twoFactorEnabled", this.dropdownHandler)}
+                                            style={styles.dropdownStyles}
+                                        />
+                                    </div>
+                                )}
 
                             {(isSuperAdmin || appSettings.uiUserActionsAccess.filterExternalAuth.visible) && (
                                 <div className="user-management-control select-active-or-inactive">

--- a/src/legacy/models/userHelpers.js
+++ b/src/legacy/models/userHelpers.js
@@ -420,9 +420,13 @@ async function getUserGroupsToSaveAndPostMetadata(d2, api, users, existingUsersT
 async function saveUsers(d2, users, d2Api, currentUser) {
     const api = d2.Api.getApi();
     const userRepository = new UserD2ApiRepository({ url: d2Api.baseUrl });
+    const version = d2?.system?.systemInfo?.version;
+    const minor = version ? Number(String(version).split(".")[1]) : undefined;
+    const is242Plus = minor !== undefined && !Number.isNaN(minor) && minor >= 42;
     const existingUsersToUpdate = await getExistingUsers(d2, {
         fields: ":owner,userCredentials,userGroups[id]",
-        filter: "userCredentials.username:in:[" + _(users).map("username").join(",") + "]",
+        filter:
+            `${is242Plus ? "username" : "userCredentials.username"}:in:[` + _(users).map("username").join(",") + "]",
     });
     const usersToSave = getUsersToSave(users, existingUsersToUpdate);
 
@@ -448,10 +452,16 @@ async function buildLogger(d2Api, currentUser) {
 
 async function saveCopyInUsers(d2, users, copyUserGroups) {
     const api = d2.Api.getApi();
+    const version = d2?.system?.systemInfo?.version;
+    const minor = version ? Number(String(version).split(".")[1]) : undefined;
+    const is242Plus = minor !== undefined && !Number.isNaN(minor) && minor >= 42;
     if (copyUserGroups) {
         const existingUsersToUpdate = await getExistingUsers(d2, {
             fields: ":owner,userCredentials,userGroups[id]",
-            filter: "userCredentials.username:in:[" + _(users).map("userCredentials.username").join(",") + "]",
+            filter:
+                `${is242Plus ? "username" : "userCredentials.username"}:in:[` +
+                _(users).map("userCredentials.username").join(",") +
+                "]",
         });
         return getUserGroupsToSaveAndPostMetadata(d2, api, users, existingUsersToUpdate);
     } else {

--- a/src/webapp/components/user-list-table/userColumns.tsx
+++ b/src/webapp/components/user-list-table/userColumns.tsx
@@ -5,15 +5,24 @@ import { User } from "../../../domain/entities/User";
 import { buildEllipsizedList } from "./UserListTable";
 import { UserColumn } from "../../../domain/entities/UserColumn";
 import i18n from "../../../utils/i18n";
+import { getMajorVersion } from "../../../utils/d2-api";
+import { useDhis2Version } from "../../hooks/userHooks";
 
 export function useUserColumns(): TableColumn<User>[] {
+    const dhis2Version = useDhis2Version();
+    const hideTwoFactorColumn = React.useMemo(() => {
+        return dhis2Version != null && getMajorVersion(dhis2Version) >= 42;
+    }, [dhis2Version]);
+
     const columns = React.useMemo(() => {
-        const columnsWithValues = getDefaultUserColumns();
+        const columnsWithValues = getDefaultUserColumns().filter(
+            col => !(hideTwoFactorColumn && col.name === UserColumn.TWO_FACTOR_ENABLED)
+        );
         return columnsWithValues.map(column => ({
             ...column,
             getValue: getValue(column.name),
         }));
-    }, []);
+    }, [hideTwoFactorColumn]);
     return columns;
 }
 

--- a/src/webapp/hooks/userHooks.ts
+++ b/src/webapp/hooks/userHooks.ts
@@ -221,6 +221,22 @@ export const useExportUsers = (props: UseExportUsersProps) => {
     };
 };
 
+/** Instance DHIS2 version string (e.g. "2.42.1"). Undefined while loading or on error. */
+export function useDhis2Version(): string | undefined {
+    const { compositionRoot } = useAppContext();
+    const [version, setVersion] = React.useState<string | undefined>(undefined);
+
+    React.useEffect(() => {
+        const cancel = compositionRoot.instance.getVersion().run(
+            v => setVersion(v),
+            () => setVersion(undefined)
+        );
+        return () => cancel();
+    }, [compositionRoot.instance]);
+
+    return version;
+}
+
 export const useColumnsPreferences = (props: UseVisibleColumnsProps) => {
     const { columnsKey, appSettings, user, onChangeVisibleColumns } = props;
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869cppt0n

### :memo: Implementation

#### Tab users
- [x] Support in d2ApiRepository to 2.42 in fields and responses
- [x] Support 2.42 filters previously in userCredentials
- [x] Support 2.42 filters previously in userCredentials in legacy code
- [x] Fix save openId and ldapId

### Refactor detected

@Ramon-Jimenez @adrianq I've detected a posible refactor in this app.

From use cases and components for filters, this code builds expressions like userCredentials.username:in:[].

The problem is that userCredentials no longer exists in version 2.42. The changes required to adapt to 2.42 should only affect the data layer.

The main issue is that there is currently a coupling between the app and DHIS2 filters. The domain, presentation and data layers are using DHIS2 filters directly. The domain should have its own filter model and adapt to and from DHIS2 filters within the repository.

To avoid a large refactor in this PR, I fixed it by using a replace function based on the version in the repository. However, this solution may be insufficient if future API versions introduce similar changes.

I think a refactor in this area is necessary.

### Questions for PMs

Previously the user filters to filter by 2factor enabled the code used userCredentials.twoFA.

<img width="1915" height="930" alt="Screenshot 2026-04-01 at 13 08 23" src="https://github.com/user-attachments/assets/41354904-b8f7-4be5-b544-d63da2f8dd3e" />

In 2.42  userCredentials is not in the response and twoFA has not been included in user.

Now if the version is 2.42 the filter has not effect because is removed in the process to avoid fail in api request.

### :video_camera: Screenshots/Screen capture

### :fire: Testing
