### PR TITLE
Feature/changes user role user groups tabs

### DIFF
--- a/i18n/ar.po
+++ b/i18n/ar.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-03-25T05:57:54.676Z\n"
+"POT-Creation-Date: 2026-04-15T08:09:38.204Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -47,17 +47,20 @@ msgstr ""
 msgid "Show Export to CSV"
 msgstr ""
 
+msgid "Show only users assigned to my organization unit and below"
+msgstr ""
+
+msgid "Hide not applicable user groups"
+msgstr ""
+
+msgid "Filter by Users"
+msgstr ""
+
 #, fuzzy
-msgid "Show \"Show only users assigned to my organization unit and below\""
-msgstr "إظهار فقط المستخدمين المعينين لوحدات تنظيم المستخدمين"
+msgid "Hide not applicable user roles"
+msgstr "تكرار المستخدم من الجدول"
 
-msgid "Show \"Hide not applicable user groups\""
-msgstr ""
-
-msgid "Show \"Filter by Users\""
-msgstr ""
-
-msgid "Show \"Filter by Owners\""
+msgid "Filter by Owners"
 msgstr ""
 
 msgid "ID"
@@ -203,9 +206,6 @@ msgid "Owners: {{owners}}"
 msgstr ""
 
 msgid "Users: {{users}}"
-msgstr ""
-
-msgid "Show only users assigned to my organization unit and below"
 msgstr ""
 
 msgid "Filters"
@@ -386,6 +386,9 @@ msgstr ""
 
 msgid "Dashboards"
 msgstr "لوحات المعلومات"
+
+msgid "Value"
+msgstr ""
 
 #, fuzzy
 msgid "Select user groups and rules"
@@ -709,9 +712,6 @@ msgstr "تكرار المستخدم من القالب"
 msgid "Replicate user from table"
 msgstr "تكرار المستخدم من الجدول"
 
-msgid "Hide not applicable user groups"
-msgstr ""
-
 msgid "Loading..."
 msgstr ""
 
@@ -991,6 +991,10 @@ msgstr "فتح في إدارة المستخدمين"
 
 msgid " and {{overflow}} more..."
 msgstr " و{{overflow}} المزيد..."
+
+#, fuzzy
+#~ msgid "Show \"Show only users assigned to my organization unit and below\""
+#~ msgstr "إظهار فقط المستخدمين المعينين لوحدات تنظيم المستخدمين"
 
 #~ msgid "Value should be between {{min}} and {{max}}"
 #~ msgstr "يجب أن تكون القيمة بين {{min}} و {{max}}"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-03-25T05:57:54.676Z\n"
-"PO-Revision-Date: 2026-03-25T05:57:54.677Z\n"
+"POT-Creation-Date: 2026-04-15T08:09:38.204Z\n"
+"PO-Revision-Date: 2026-04-15T08:09:38.204Z\n"
 
 msgid "Invalid response from server"
 msgstr ""
@@ -47,16 +47,19 @@ msgstr ""
 msgid "Show Export to CSV"
 msgstr ""
 
-msgid "Show \"Show only users assigned to my organization unit and below\""
+msgid "Show only users assigned to my organization unit and below"
 msgstr ""
 
-msgid "Show \"Hide not applicable user groups\""
+msgid "Hide not applicable user groups"
 msgstr ""
 
-msgid "Show \"Filter by Users\""
+msgid "Filter by Users"
 msgstr ""
 
-msgid "Show \"Filter by Owners\""
+msgid "Hide not applicable user roles"
+msgstr ""
+
+msgid "Filter by Owners"
 msgstr ""
 
 msgid "ID"
@@ -201,9 +204,6 @@ msgid "Owners: {{owners}}"
 msgstr ""
 
 msgid "Users: {{users}}"
-msgstr ""
-
-msgid "Show only users assigned to my organization unit and below"
 msgstr ""
 
 msgid "Filters"
@@ -378,6 +378,9 @@ msgid "Show/Hide Actions"
 msgstr ""
 
 msgid "Dashboards"
+msgstr ""
+
+msgid "Value"
 msgstr ""
 
 msgid "Select user groups and rules"
@@ -688,9 +691,6 @@ msgid "Replicate user from template"
 msgstr ""
 
 msgid "Replicate user from table"
-msgstr ""
-
-msgid "Hide not applicable user groups"
 msgstr ""
 
 msgid "Loading..."

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-03-25T05:57:54.676Z\n"
+"POT-Creation-Date: 2026-04-15T08:09:38.204Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -47,17 +47,23 @@ msgstr ""
 msgid "Show Export to CSV"
 msgstr ""
 
-msgid "Show \"Show only users assigned to my organization unit and below\""
+msgid "Show only users assigned to my organization unit and below"
 msgstr ""
 
-msgid "Show \"Hide not applicable user groups\""
-msgstr "Mostrar \"Ocultar grupos sin usuarios\""
+msgid "Hide not applicable user groups"
+msgstr "Ocultar grupos sin usuarios"
 
-msgid "Show \"Filter by Users\""
-msgstr "Mostrar Filtrar usuarios"
+#, fuzzy
+msgid "Filter by Users"
+msgstr "Filtrar usuarios"
 
-msgid "Show \"Filter by Owners\""
-msgstr ""
+#, fuzzy
+msgid "Hide not applicable user roles"
+msgstr "Ocultar grupos sin usuarios"
+
+#, fuzzy
+msgid "Filter by Owners"
+msgstr "Filtrar usuarios"
 
 msgid "ID"
 msgstr "ID"
@@ -202,9 +208,6 @@ msgstr ""
 
 msgid "Users: {{users}}"
 msgstr "Usuarios: {{users}}"
-
-msgid "Show only users assigned to my organization unit and below"
-msgstr ""
 
 msgid "Filters"
 msgstr "Filtros"
@@ -380,6 +383,9 @@ msgstr "Mostrar/Ocultar Acciones"
 
 msgid "Dashboards"
 msgstr "Tableros"
+
+msgid "Value"
+msgstr ""
 
 msgid "Select user groups and rules"
 msgstr "Seleccionar grupos y roles"
@@ -696,9 +702,6 @@ msgstr "Replicar usuario desde plantilla"
 msgid "Replicate user from table"
 msgstr "Replicar usuario desde tabla"
 
-msgid "Hide not applicable user groups"
-msgstr "Ocultar grupos sin usuarios"
-
 msgid "Loading..."
 msgstr "Cargando..."
 
@@ -976,3 +979,9 @@ msgstr "Abrir en Administración de usuarios"
 
 msgid " and {{overflow}} more..."
 msgstr " y {{overflow}} más..."
+
+#~ msgid "Show \"Hide not applicable user groups\""
+#~ msgstr "Mostrar \"Ocultar grupos sin usuarios\""
+
+#~ msgid "Show \"Filter by Users\""
+#~ msgstr "Mostrar Filtrar usuarios"

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-03-25T05:57:54.676Z\n"
+"POT-Creation-Date: 2026-04-15T08:09:38.204Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -47,17 +47,23 @@ msgstr ""
 msgid "Show Export to CSV"
 msgstr ""
 
-msgid "Show \"Show only users assigned to my organization unit and below\""
+msgid "Show only users assigned to my organization unit and below"
 msgstr ""
 
-msgid "Show \"Hide not applicable user groups\""
+msgid "Hide not applicable user groups"
 msgstr ""
 
-msgid "Show \"Filter by Users\""
-msgstr ""
+#, fuzzy
+msgid "Filter by Users"
+msgstr "Filtrer"
 
-msgid "Show \"Filter by Owners\""
-msgstr ""
+#, fuzzy
+msgid "Hide not applicable user roles"
+msgstr "Répliquer l'utilisateur à partir du tableau"
+
+#, fuzzy
+msgid "Filter by Owners"
+msgstr "Filtrer"
 
 msgid "ID"
 msgstr "ID"
@@ -202,9 +208,6 @@ msgid "Owners: {{owners}}"
 msgstr ""
 
 msgid "Users: {{users}}"
-msgstr ""
-
-msgid "Show only users assigned to my organization unit and below"
 msgstr ""
 
 msgid "Filters"
@@ -387,6 +390,9 @@ msgid "Show/Hide Actions"
 msgstr ""
 
 msgid "Dashboards"
+msgstr ""
+
+msgid "Value"
 msgstr ""
 
 #, fuzzy
@@ -720,9 +726,6 @@ msgstr "Répliquer l'utilisateur à partir du modèle"
 
 msgid "Replicate user from table"
 msgstr "Répliquer l'utilisateur à partir du tableau"
-
-msgid "Hide not applicable user groups"
-msgstr ""
 
 msgid "Loading..."
 msgstr ""

--- a/i18n/pt.po
+++ b/i18n/pt.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-03-25T05:57:54.676Z\n"
+"POT-Creation-Date: 2026-04-15T08:09:38.204Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -47,16 +47,20 @@ msgstr ""
 msgid "Show Export to CSV"
 msgstr ""
 
-msgid "Show \"Show only users assigned to my organization unit and below\""
+msgid "Show only users assigned to my organization unit and below"
 msgstr ""
 
-msgid "Show \"Hide not applicable user groups\""
+msgid "Hide not applicable user groups"
 msgstr ""
 
-msgid "Show \"Filter by Users\""
+msgid "Filter by Users"
 msgstr ""
 
-msgid "Show \"Filter by Owners\""
+#, fuzzy
+msgid "Hide not applicable user roles"
+msgstr "Replicar utilizador a partir da tabela"
+
+msgid "Filter by Owners"
 msgstr ""
 
 msgid "ID"
@@ -202,9 +206,6 @@ msgid "Owners: {{owners}}"
 msgstr ""
 
 msgid "Users: {{users}}"
-msgstr ""
-
-msgid "Show only users assigned to my organization unit and below"
 msgstr ""
 
 msgid "Filters"
@@ -387,6 +388,9 @@ msgstr ""
 
 msgid "Dashboards"
 msgstr "Painéis"
+
+msgid "Value"
+msgstr ""
 
 #, fuzzy
 msgid "Select user groups and rules"
@@ -718,9 +722,6 @@ msgstr "Replicar utilizador a partir do modelo"
 
 msgid "Replicate user from table"
 msgstr "Replicar utilizador a partir da tabela"
-
-msgid "Hide not applicable user groups"
-msgstr ""
 
 msgid "Loading..."
 msgstr ""

--- a/i18n/pt_BR.po
+++ b/i18n/pt_BR.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2026-03-25T05:57:54.676Z\n"
+"POT-Creation-Date: 2026-04-15T08:09:38.204Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -47,16 +47,20 @@ msgstr ""
 msgid "Show Export to CSV"
 msgstr ""
 
-msgid "Show \"Show only users assigned to my organization unit and below\""
+msgid "Show only users assigned to my organization unit and below"
 msgstr ""
 
-msgid "Show \"Hide not applicable user groups\""
+msgid "Hide not applicable user groups"
 msgstr ""
 
-msgid "Show \"Filter by Users\""
+msgid "Filter by Users"
 msgstr ""
 
-msgid "Show \"Filter by Owners\""
+#, fuzzy
+msgid "Hide not applicable user roles"
+msgstr "Replicar usuário a partir da tabela"
+
+msgid "Filter by Owners"
 msgstr ""
 
 msgid "ID"
@@ -202,9 +206,6 @@ msgid "Owners: {{owners}}"
 msgstr ""
 
 msgid "Users: {{users}}"
-msgstr ""
-
-msgid "Show only users assigned to my organization unit and below"
 msgstr ""
 
 msgid "Filters"
@@ -386,6 +387,9 @@ msgid "Show/Hide Actions"
 msgstr ""
 
 msgid "Dashboards"
+msgstr ""
+
+msgid "Value"
 msgstr ""
 
 #, fuzzy
@@ -715,9 +719,6 @@ msgstr "Replicar usuário a partir do modelo"
 
 msgid "Replicate user from table"
 msgstr "Replicar usuário a partir da tabela"
-
-msgid "Hide not applicable user groups"
-msgstr ""
 
 msgid "Loading..."
 msgstr ""

--- a/src/CompositionRoot.ts
+++ b/src/CompositionRoot.ts
@@ -42,6 +42,7 @@ import { GetUserRolesUseCase } from "./domain/usecases/GetUserRolesUseCase";
 import { OrgUnitD2Repository } from "./data/repositories/OrgUnitD2Repository";
 import { GetUserGroupsUseCase } from "./domain/usecases/GetUserGroupsUseCase";
 import { GetUsersInOrgUnits } from "./domain/usecases/GetUsersInOrgUnits";
+import { GetAllUsersSimpleUseCase } from "./domain/usecases/GetAllUsersSimpleUseCase";
 import { UserSimpleD2Repository } from "./data/repositories/UserSimpleD2Repository";
 import { AppSettingsD2ConstantRepository } from "./data/repositories/AppSettingsD2ConstantRepository";
 import { SetUserPasswordUseCase } from "./domain/usecases/SetUserPasswordUseCase";
@@ -115,6 +116,7 @@ export function getCompositionRoot(instance: Instance, storageType: SettingsStor
                 appSettingsRepository
             ),
             getInOrgUnits: new GetUsersInOrgUnits(orgUnitRepository, userSimpleRepository, appSettingsRepository),
+            getAllSimple: new GetAllUsersSimpleUseCase(userRepository, appSettingsRepository),
             resetColumns: new ResetColumnsUserCase(userColumnRepository),
             replicateFromTemplate: new ReplicateFromTemplateUseCase(userRepository),
         }),

--- a/src/data/repositories/UserRoleD2Repository.ts
+++ b/src/data/repositories/UserRoleD2Repository.ts
@@ -1,6 +1,6 @@
 import _ from "lodash";
-import { D2Api } from "../../types/d2-api";
-import { FutureData } from "../../domain/entities/Future";
+import { D2Api, Id } from "../../types/d2-api";
+import { Future, FutureData } from "../../domain/entities/Future";
 import { PaginatedResponse } from "../../domain/entities/PaginatedResponse";
 import { UserRole } from "../../domain/entities/UserRole";
 import { apiToFuture } from "../../utils/futures";
@@ -34,6 +34,7 @@ export class UserRoleD2Repository implements UserRoleRepository {
                     description: { ilike: options.search },
                     "users.id": { in: userIdsToFilters },
                     id: options.hideRoles && options.hideRoles.length > 0 ? { "!in": options.hideRoles } : undefined,
+                    users: options.hideEmptyUsers ? { gt: "0" } : undefined,
                 },
                 rootJunction: "OR",
                 page: options.page,
@@ -64,4 +65,53 @@ export class UserRoleD2Repository implements UserRoleRepository {
             };
         });
     }
+
+    getAllBy(options: { hideUsers: Id[]; hideRoles: Id[] }): FutureData<UserRole[]> {
+        return this.getAllUserRoles({ initialPage: 1, pageSize: 100 }).map(d2UserRoles => {
+            return d2UserRoles
+                .filter(role => !options.hideRoles.includes(role.id))
+                .map(role => {
+                    const filteredUsers = role.users.filter(user => !options.hideUsers.includes(user.id));
+                    return UserRole.create({
+                        id: role.id,
+                        name: role.displayName,
+                        description: role.description,
+                        users: filteredUsers.map(user => ({ id: user.id, name: user.displayName })),
+                    });
+                });
+        });
+    }
+
+    private getAllUserRoles(options: { initialPage: number; pageSize: number }): FutureData<D2ApiUserRole[]> {
+        const { initialPage, pageSize } = options;
+
+        const fetchByPage = (page: number): FutureData<D2ApiUserRole[]> => {
+            return apiToFuture(
+                this.api.models.userRoles.get({
+                    fields: { id: true, displayName: true, description: true, users: { id: true, displayName: true } },
+                    page,
+                    pageSize,
+                })
+            ).flatMap(response => {
+                const userGroups = response.objects;
+                if (response.pager.page < response.pager.pageCount) {
+                    return fetchByPage(page + 1).map(nextUserGroups => userGroups.concat(nextUserGroups));
+                } else {
+                    return Future.success(userGroups);
+                }
+            });
+        };
+
+        return fetchByPage(initialPage);
+    }
 }
+
+type D2ApiUserRole = {
+    id: string;
+    displayName: string;
+    description: string;
+    users: Array<{
+        id: string;
+        displayName: string;
+    }>;
+};

--- a/src/data/repositories/common/__tests__/appSettingsHelpers.spec.ts
+++ b/src/data/repositories/common/__tests__/appSettingsHelpers.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { AppSettings } from "../../../../domain/entities/AppSettings";
+import { ActionPermission } from "../../../../domain/entities/ActionPermission";
+import { UserAction } from "../../../../domain/entities/UserAction";
+import { mergeAndAddRuntimeProps } from "../appSettingsHelpers";
+
+describe("mergeAndAddRuntimeProps", () => {
+    it("returns inactive defaults when input is undefined", () => {
+        const result = mergeAndAddRuntimeProps(undefined);
+
+        expect(result.status).toBe("inactive");
+        expect(result.uiUserGroupActionsAccess.filterUsersInOrgUnit).toEqual({
+            visible: true,
+            defaultValue: true,
+        });
+    });
+
+    it("returns active defaults when input is an empty object", () => {
+        const result = mergeAndAddRuntimeProps({});
+
+        expect(result.status).toBe("active");
+        expect(result.uiUserGroupActionsAccess.filterUsersInOrgUnit).toEqual({
+            visible: true,
+            defaultValue: true,
+        });
+    });
+
+    it("fills defaultValue from defaults when stored entry only has visible (legacy storage)", () => {
+        const legacyStored: Partial<AppSettings> = {
+            uiUserGroupActionsAccess: {
+                filterUsersInOrgUnit: { visible: false },
+                filterHideNotApplicableUserGroups: { visible: true },
+                filterUsers: { visible: true },
+                exportCsv: { visible: true },
+                exportJson: { visible: true },
+            },
+        };
+
+        const result = mergeAndAddRuntimeProps(legacyStored);
+
+        expect(result.uiUserGroupActionsAccess.filterUsersInOrgUnit).toEqual({
+            visible: false,
+            defaultValue: true,
+        });
+        expect(result.uiUserGroupActionsAccess.filterHideNotApplicableUserGroups).toEqual({
+            visible: true,
+            defaultValue: true,
+        });
+    });
+
+    it("preserves stored defaultValue when both fields are present", () => {
+        const stored: Partial<AppSettings> = {
+            uiUserRoleActionsAccess: {
+                filterUsersInOrgUnit: { visible: true, defaultValue: false },
+                filterHideNotApplicableUserRoles: { visible: false, defaultValue: false },
+                filterUsers: { visible: true },
+            },
+        };
+
+        const result = mergeAndAddRuntimeProps(stored);
+
+        expect(result.uiUserRoleActionsAccess.filterUsersInOrgUnit).toEqual({
+            visible: true,
+            defaultValue: false,
+        });
+        expect(result.uiUserRoleActionsAccess.filterHideNotApplicableUserRoles).toEqual({
+            visible: false,
+            defaultValue: false,
+        });
+    });
+
+    it("adds missing ui action keys from defaults (forward-compatible migration)", () => {
+        const storedMissingKey: Partial<AppSettings> = {
+            uiDashboardActionsAccess: {
+                filterUsersInOrgUnit: { visible: false, defaultValue: false },
+            } as AppSettings["uiDashboardActionsAccess"],
+        };
+
+        const result = mergeAndAddRuntimeProps(storedMissingKey);
+
+        expect(result.uiDashboardActionsAccess.filterUsersInOrgUnit).toEqual({
+            visible: false,
+            defaultValue: false,
+        });
+        expect(result.uiDashboardActionsAccess.filterUsers).toEqual({ visible: true });
+        expect(result.uiDashboardActionsAccess.filterOwners).toEqual({ visible: true });
+    });
+
+    it("fills missing actionsAccess entries from defaults", () => {
+        const defaults = AppSettings.defaultSettings("active");
+        const partialActionsAccess = { ...defaults.actionsAccess };
+        delete (partialActionsAccess as Partial<typeof partialActionsAccess>)[UserAction.DETAILS];
+
+        const result = mergeAndAddRuntimeProps({ actionsAccess: partialActionsAccess });
+
+        expect(result.actionsAccess[UserAction.DETAILS]).toBeInstanceOf(ActionPermission);
+        expect(result.actionsAccess[UserAction.EDIT]).toBeInstanceOf(ActionPermission);
+    });
+});

--- a/src/data/repositories/common/appSettingsHelpers.ts
+++ b/src/data/repositories/common/appSettingsHelpers.ts
@@ -1,13 +1,8 @@
 import _ from "lodash";
-import {
-    ActionsPermissions,
-    AppSettings,
-    injectInternalRules,
-    removeInternalRules,
-} from "../../../domain/entities/AppSettings";
+import { AppSettings, injectInternalRules, removeInternalRules } from "../../../domain/entities/AppSettings";
 import { Permission } from "../../../domain/entities/Permission";
 import { ActionPermission } from "../../../domain/entities/ActionPermission";
-import { getKeys, Maybe } from "../../../types/utils";
+import { Maybe } from "../../../types/utils";
 
 //FIXME (NOT URGENT): shouldn't be a Maybe if Request result is compared with Codec.
 // Partial, as new props can be added on next releases.
@@ -19,40 +14,58 @@ export function mergeAndAddRuntimeProps(appSettings: Maybe<Partial<AppSettings>>
         ? new Permission(appSettings.settingsAccess)
         : emptySettings.settingsAccess;
 
-    const actionsAccess = appSettings.actionsAccess
+    const storedActionsAccess = appSettings.actionsAccess
         ? _.mapValues(appSettings.actionsAccess, p => new ActionPermission(p))
         : emptySettings.actionsAccess;
 
-    const forcedActionsAccess = injectInternalRules(migrateNewerActions(actionsAccess));
+    const forcedActionsAccess = injectInternalRules(
+        migrateRecord(storedActionsAccess, emptySettings.actionsAccess, (def, stored) => stored ?? def)
+    );
+
     const newAppSettings = {
         ...emptySettings,
         ...appSettings,
         settingsAccess: settingsAccess,
         actionsAccess: forcedActionsAccess,
+        uiUserGroupActionsAccess: migrateRecord(
+            appSettings.uiUserGroupActionsAccess,
+            emptySettings.uiUserGroupActionsAccess,
+            mergeEntryShallow
+        ),
+        uiUserRoleActionsAccess: migrateRecord(
+            appSettings.uiUserRoleActionsAccess,
+            emptySettings.uiUserRoleActionsAccess,
+            mergeEntryShallow
+        ),
+        uiDashboardActionsAccess: migrateRecord(
+            appSettings.uiDashboardActionsAccess,
+            emptySettings.uiDashboardActionsAccess,
+            mergeEntryShallow
+        ),
     };
 
     return AppSettings.create(newAppSettings);
 }
 
-/* New actions may be added in the future, so we need to ensure that
- the actionsAccess object contains all actions, even if they are not defined in the appSettings
- that could be already saved.
+/* Ensures a record contains all keys from `defaults`, even if the stored value
+ * is missing or partial. New keys added in future releases get their default
+ * value automatically. `mergeEntry` decides whether to replace the whole entry
+ * (for class instances) or merge fields within it (for plain objects).
  */
-function migrateNewerActions(actionsAccess: ActionsPermissions): ActionsPermissions {
-    const newActionsAccess = AppSettings.defaultSettings("active").actionsAccess;
+function migrateRecord<K extends string, V>(
+    stored: Maybe<Partial<Record<K, V>>>,
+    defaults: Record<K, V>,
+    mergeEntry: (defaultEntry: V, storedEntry: V | undefined) => V
+): Record<K, V> {
+    if (!stored) return defaults;
+    return _.mapValues(defaults, (defaultEntry, key) => mergeEntry(defaultEntry as V, stored[key as K])) as Record<
+        K,
+        V
+    >;
+}
 
-    const newerActions = getKeys(newActionsAccess);
-    const currentActions = getKeys(actionsAccess);
-
-    const actionsToMigrate = newerActions.filter(action => !currentActions.includes(action));
-    if (actionsToMigrate.length === 0) return actionsAccess;
-
-    const newActions = _.pick(newActionsAccess, actionsToMigrate);
-
-    return {
-        ...actionsAccess,
-        ...newActions,
-    };
+function mergeEntryShallow<V extends Record<string, unknown>>(defaultEntry: V, storedEntry: V | undefined): V {
+    return { ...defaultEntry, ...(storedEntry ?? ({} as V)) };
 }
 
 export function removeRuntimeLogic(appSettings: AppSettings): AppSettings {

--- a/src/domain/entities/AppSettings.ts
+++ b/src/domain/entities/AppSettings.ts
@@ -172,8 +172,8 @@ export class AppSettings extends Struct<AppSettingsAttr>() {
 
     private static defaultUserGroupUiActions(): AppSettingsAttr["uiUserGroupActionsAccess"] {
         return {
-            filterHideNotApplicableUserGroups: { visible: true },
-            filterUsersInOrgUnit: { visible: true },
+            filterHideNotApplicableUserGroups: { visible: true, defaultValue: true },
+            filterUsersInOrgUnit: { visible: true, defaultValue: true },
             filterUsers: { visible: true },
             exportCsv: { visible: true },
             exportJson: { visible: true },
@@ -182,15 +182,15 @@ export class AppSettings extends Struct<AppSettingsAttr>() {
 
     private static defaultUserRoleUiActions(): AppSettingsAttr["uiUserRoleActionsAccess"] {
         return {
-            filterHideNotApplicableUserRoles: { visible: true },
-            filterUsersInOrgUnit: { visible: true },
+            filterHideNotApplicableUserRoles: { visible: true, defaultValue: true },
+            filterUsersInOrgUnit: { visible: true, defaultValue: true },
             filterUsers: { visible: true },
         };
     }
 
     private static defaultUiDashboardActions(): AppSettingsAttr["uiDashboardActionsAccess"] {
         return {
-            filterUsersInOrgUnit: { visible: true },
+            filterUsersInOrgUnit: { visible: true, defaultValue: true },
             filterUsers: { visible: true },
             filterOwners: { visible: true },
         };

--- a/src/domain/entities/AppSettings.ts
+++ b/src/domain/entities/AppSettings.ts
@@ -181,7 +181,11 @@ export class AppSettings extends Struct<AppSettingsAttr>() {
     }
 
     private static defaultUserRoleUiActions(): AppSettingsAttr["uiUserRoleActionsAccess"] {
-        return { filterUsersInOrgUnit: { visible: true }, filterUsers: { visible: true } };
+        return {
+            filterHideNotApplicableUserRoles: { visible: true },
+            filterUsersInOrgUnit: { visible: true },
+            filterUsers: { visible: true },
+        };
     }
 
     private static defaultUiDashboardActions(): AppSettingsAttr["uiDashboardActionsAccess"] {

--- a/src/domain/entities/FilterUserActionPermission.ts
+++ b/src/domain/entities/FilterUserActionPermission.ts
@@ -53,15 +53,15 @@ export type UserUiActionAccess = Record<UIUserActionType, { visible: boolean }>;
 export const UI_USER_GROUP_ACTION_LIST = [
     {
         code: "filterUsersInOrgUnit",
-        label: i18n.t('Show "Show only users assigned to my organization unit and below"'),
+        label: i18n.t("Show only users assigned to my organization unit and below"),
     },
     {
         code: "filterHideNotApplicableUserGroups",
-        label: i18n.t('Show "Hide not applicable user groups"'),
+        label: i18n.t("Hide not applicable user groups"),
     },
     {
         code: "filterUsers",
-        label: i18n.t('Show "Filter by Users"'),
+        label: i18n.t("Filter by Users"),
     },
     {
         code: "exportCsv",
@@ -74,40 +74,40 @@ export const UI_USER_GROUP_ACTION_LIST = [
 ] as const;
 
 export type UIUserGroupActionType = typeof UI_USER_GROUP_ACTION_LIST[number]["code"];
-export type UserGroupUiActionAccess = Record<UIUserGroupActionType, { visible: boolean }>;
+export type UserGroupUiActionAccess = Record<UIUserGroupActionType, { visible: boolean; defaultValue?: boolean }>;
 
 export const UI_USER_ROLE_ACTION_LIST = [
     {
         code: "filterUsersInOrgUnit",
-        label: i18n.t('Show "Show only users assigned to my organization unit and below"'),
+        label: i18n.t("Show only users assigned to my organization unit and below"),
     },
     {
         code: "filterHideNotApplicableUserRoles",
-        label: i18n.t('Show "Hide not applicable user roles"'),
+        label: i18n.t("Hide not applicable user roles"),
     },
     {
         code: "filterUsers",
-        label: i18n.t('Show "Filter by Users"'),
+        label: i18n.t("Filter by Users"),
     },
 ] as const;
 
 export type UIUserRoleActionType = typeof UI_USER_ROLE_ACTION_LIST[number]["code"];
-export type UserRoleUiActionAccess = Record<UIUserRoleActionType, { visible: boolean }>;
+export type UserRoleUiActionAccess = Record<UIUserRoleActionType, { visible: boolean; defaultValue?: boolean }>;
 
 export const UI_DASHBOARD_ACTION_LIST = [
     {
         code: "filterUsersInOrgUnit",
-        label: i18n.t('Show "Show only users assigned to my organization unit and below"'),
+        label: i18n.t("Show only users assigned to my organization unit and below"),
     },
     {
         code: "filterUsers",
-        label: i18n.t('Show "Filter by Users"'),
+        label: i18n.t("Filter by Users"),
     },
     {
         code: "filterOwners",
-        label: i18n.t('Show "Filter by Owners"'),
+        label: i18n.t("Filter by Owners"),
     },
 ] as const;
 
 export type UIDashboardActionType = typeof UI_DASHBOARD_ACTION_LIST[number]["code"];
-export type DashboardUiActionAccess = Record<UIDashboardActionType, { visible: boolean }>;
+export type DashboardUiActionAccess = Record<UIDashboardActionType, { visible: boolean; defaultValue?: boolean }>;

--- a/src/domain/entities/FilterUserActionPermission.ts
+++ b/src/domain/entities/FilterUserActionPermission.ts
@@ -82,6 +82,10 @@ export const UI_USER_ROLE_ACTION_LIST = [
         label: i18n.t('Show "Show only users assigned to my organization unit and below"'),
     },
     {
+        code: "filterHideNotApplicableUserRoles",
+        label: i18n.t('Show "Hide not applicable user roles"'),
+    },
+    {
         code: "filterUsers",
         label: i18n.t('Show "Filter by Users"'),
     },

--- a/src/domain/repositories/UserRoleRepository.ts
+++ b/src/domain/repositories/UserRoleRepository.ts
@@ -7,10 +7,12 @@ import { UserRole } from "../entities/UserRole";
 export interface UserRoleRepository {
     getAll(): FutureData<UserRole[]>;
     get(options: GetUserRolesParams): FutureData<PaginatedResponse<UserRole>>;
+    getAllBy(options: { hideUsers: Maybe<Id[]>; hideRoles: Maybe<Id[]> }): FutureData<UserRole[]>;
 }
 
 export type GetUserRolesParams = CommonFilterParams & {
     hideRoles: Maybe<Id[]>;
     hideUsers: Maybe<Id[]>;
     userIds: Maybe<Id[]>;
+    hideEmptyUsers?: boolean;
 };

--- a/src/domain/usecases/GetAllUsersSimpleUseCase.ts
+++ b/src/domain/usecases/GetAllUsersSimpleUseCase.ts
@@ -1,0 +1,34 @@
+import { FutureData } from "../entities/Future";
+import { UserSimple } from "../entities/UserSimple";
+import { UserProps } from "../entities/UserProps";
+import { AppSettingsRepository } from "../repositories/AppSettingsRepository";
+import { UserRepository } from "../repositories/UserRepository";
+import { getAppSettings } from "./common/settings";
+
+/** Lists every user visible to the API, excluding ids in app settings `hide.users` (same idea as {@link GetUsersInOrgUnits}). */
+export class GetAllUsersSimpleUseCase {
+    constructor(private userRepository: UserRepository, private appSettingsRepository: AppSettingsRepository) {}
+
+    execute(user: UserProps): FutureData<UserSimple[]> {
+        return getAppSettings(this.appSettingsRepository, user).flatMap(appSettings => {
+            return this.userRepository
+                .listAllUserIdentifiers({
+                    onlyUsersOrgUnits: false,
+                    onlyActiveUsers: false,
+                    hideUsers: appSettings.hide.users,
+                })
+                .map(identifiers =>
+                    identifiers.map(identifier =>
+                        UserSimple.create({
+                            id: identifier.id,
+                            name: identifier.name,
+                            firstName: identifier.name,
+                            lastName: "",
+                            email: "",
+                            username: identifier.username,
+                        })
+                    )
+                );
+        });
+    }
+}

--- a/src/domain/usecases/GetUserRolesUseCase.ts
+++ b/src/domain/usecases/GetUserRolesUseCase.ts
@@ -1,8 +1,5 @@
-import { Maybe } from "../../types/utils";
 import { AppSettings } from "../entities/AppSettings";
 import { Future, FutureData } from "../entities/Future";
-import { CommonFilterParams, PaginatedResponse } from "../entities/PaginatedResponse";
-import { Id } from "../entities/Ref";
 import { UserProps } from "../entities/UserProps";
 import { UserRole } from "../entities/UserRole";
 import { AppSettingsRepository } from "../repositories/AppSettingsRepository";
@@ -18,39 +15,28 @@ export class GetUserRolesUseCase {
         private userRepository: UserRepository
     ) {}
 
-    execute(options: GetUsersCommonOptions): FutureData<PaginatedResponse<UserRole>> {
+    execute(options: { user: UserProps; excludeUsersOutsideOrgUnits: boolean }): FutureData<UserRole[]> {
         return getAppSettings(this.appSettingsRepository, options.user).flatMap(appSettings => {
-            if (!options.excludeUsersOutsideOrgUnits) return this.getRoles(options, appSettings);
+            if (!options.excludeUsersOutsideOrgUnits) return this.getRoles(appSettings);
 
-            return this.getUsersAndRoles(options, appSettings).map(({ usersInMyOrgUnit, rolesPaginated }) => {
-                const usersRolesWithFilteredUsers = excludeUsers(usersInMyOrgUnit, rolesPaginated.objects);
-                return { ...rolesPaginated, objects: usersRolesWithFilteredUsers };
+            return this.getUsersAndRoles(appSettings).map(({ usersInMyOrgUnit, roles }) => {
+                const usersRolesWithFilteredUsers = excludeUsers(usersInMyOrgUnit, roles);
+                return usersRolesWithFilteredUsers;
             });
         });
     }
 
-    private getUsersAndRoles(options: GetUsersCommonOptions, appSettings: AppSettings) {
+    private getUsersAndRoles(appSettings: AppSettings) {
         return Future.joinObj({
             usersInMyOrgUnit: this.userRepository.getInMyOrgUnit(),
-            rolesPaginated: this.getRoles(options, appSettings),
+            roles: this.getRoles(appSettings),
         });
     }
 
-    private getRoles(
-        options: GetUsersCommonOptions,
-        appSettings: AppSettings
-    ): FutureData<PaginatedResponse<UserRole>> {
-        return this.userRoleRepository.get({
-            ...options,
+    private getRoles(appSettings: AppSettings): FutureData<UserRole[]> {
+        return this.userRoleRepository.getAllBy({
             hideRoles: appSettings.hide.userRoles,
             hideUsers: appSettings.hide.users,
-            userIds: options.userIds,
         });
     }
 }
-
-export type GetUsersCommonOptions = CommonFilterParams & {
-    excludeUsersOutsideOrgUnits: boolean;
-    user: UserProps;
-    userIds: Maybe<Id[]>;
-};

--- a/src/webapp/components/dashboard/DashboardFilters.tsx
+++ b/src/webapp/components/dashboard/DashboardFilters.tsx
@@ -28,7 +28,9 @@ export const DashboardFilters: React.FC<DashboardsFiltersProps> = React.memo(pro
     const [showUserFilterModal, setShowUserFilterModal] = React.useState(false);
     const [showOwnerFilterModal, setShowOwnerFilterModal] = React.useState(false);
     const [openFilterDialog, setOpenFilterDialog] = React.useState(false);
-    const [excludeUsersOutsideOrgUnits, setExcludeUsersOutsideOrgUnits] = React.useState(true);
+    const [excludeUsersOutsideOrgUnits, setExcludeUsersOutsideOrgUnits] = React.useState(
+        appSettings.uiDashboardActionsAccess.filterUsersInOrgUnit.defaultValue ?? true
+    );
     const [ids, selectedIds] = React.useState<Id[]>([]);
     const [ownerIds, selectedOwnerIds] = React.useState<Id[]>([]);
 

--- a/src/webapp/components/dashboard/DashboardTable.tsx
+++ b/src/webapp/components/dashboard/DashboardTable.tsx
@@ -51,6 +51,8 @@ function generateTableConfig(dashboardColumns: DashboardColumnSetting[], user: U
 
 export const DashboardTable: React.FC<DashboardTableProps> = React.memo(props => {
     const { appSettings } = props;
+    const defaultExcludeUsersOutsideOrgUnits =
+        appSettings.uiDashboardActionsAccess.filterUsersInOrgUnit.defaultValue ?? true;
     const { compositionRoot, currentUser } = useAppContext();
     const [filters, setFilters] = React.useState<{
         ownerUsersIds?: Id[];
@@ -59,7 +61,7 @@ export const DashboardTable: React.FC<DashboardTableProps> = React.memo(props =>
     }>({
         ownerUsersIds: undefined,
         userIds: undefined,
-        excludeUsersOutsideOrgUnits: true,
+        excludeUsersOutsideOrgUnits: defaultExcludeUsersOutsideOrgUnits,
     });
     const [dashboards, setDashboards] = React.useState<Dashboard[]>([]);
     const [loading, setLoading] = React.useState(false);

--- a/src/webapp/components/permissions-page/PermissionsPage.tsx
+++ b/src/webapp/components/permissions-page/PermissionsPage.tsx
@@ -26,7 +26,20 @@ import {
     UI_USER_ACTION_LIST,
     UI_USER_GROUP_ACTION_LIST,
     UI_USER_ROLE_ACTION_LIST,
+    UIDashboardActionType,
+    UIUserGroupActionType,
+    UIUserRoleActionType,
 } from "../../../domain/entities/FilterUserActionPermission";
+
+const BOOLEAN_USER_GROUP_FILTERS: readonly UIUserGroupActionType[] = [
+    "filterUsersInOrgUnit",
+    "filterHideNotApplicableUserGroups",
+];
+const BOOLEAN_USER_ROLE_FILTERS: readonly UIUserRoleActionType[] = [
+    "filterUsersInOrgUnit",
+    "filterHideNotApplicableUserRoles",
+];
+const BOOLEAN_DASHBOARD_FILTERS: readonly UIDashboardActionType[] = ["filterUsersInOrgUnit"];
 
 type PermissionsPageProps = {
     onSave: (appSettings: AppSettings) => void;
@@ -253,33 +266,52 @@ export const PermissionsPage = React.memo((props: PermissionsPageProps) => {
                                     flexDirection="column"
                                     gridRowGap={theme.spacing(1)}
                                 >
-                                    <Typography variant="h6">{i18n.t("Show/Hide Filters")}</Typography>
-                                    {UI_USER_GROUP_ACTION_LIST.map(action => {
-                                        return (
-                                            <div key={action.code}>
-                                                {action.code === "exportCsv" && (
-                                                    <Typography variant="h6">{i18n.t("Show/Hide Actions")}</Typography>
-                                                )}
-                                                <FormControlLabel
-                                                    control={
-                                                        <Switch
-                                                            checked={
-                                                                formState.uiUserGroupActionsAccess[action.code].visible
-                                                            }
-                                                            onChange={event =>
-                                                                updateUiUserGroupActionsAccess(
-                                                                    action.code,
-                                                                    event.target.checked
-                                                                )
-                                                            }
-                                                        />
-                                                    }
-                                                    label={action.label}
+                                    <Typography variant="h6">{i18n.t("Filters")}</Typography>
+                                    <FiltersGrid>
+                                        <FiltersGridHeader />
+                                        {UI_USER_GROUP_ACTION_LIST.filter(
+                                            a => a.code !== "exportCsv" && a.code !== "exportJson"
+                                        ).map(action => {
+                                            const entry = formState.uiUserGroupActionsAccess[action.code];
+                                            const isBoolean = BOOLEAN_USER_GROUP_FILTERS.includes(action.code);
+                                            return (
+                                                <FilterRow
                                                     key={action.code}
+                                                    label={action.label}
+                                                    visible={entry.visible}
+                                                    defaultValue={entry.defaultValue}
+                                                    isBoolean={isBoolean}
+                                                    onVisibleChange={v =>
+                                                        updateUiUserGroupActionsAccess(action.code, "visible", v)
+                                                    }
+                                                    onDefaultChange={v =>
+                                                        updateUiUserGroupActionsAccess(action.code, "defaultValue", v)
+                                                    }
                                                 />
-                                            </div>
-                                        );
-                                    })}
+                                            );
+                                        })}
+                                    </FiltersGrid>
+                                    <Typography variant="h6">{i18n.t("Show/Hide Actions")}</Typography>
+                                    {UI_USER_GROUP_ACTION_LIST.filter(
+                                        a => a.code === "exportCsv" || a.code === "exportJson"
+                                    ).map(action => (
+                                        <FormControlLabel
+                                            control={
+                                                <Switch
+                                                    checked={formState.uiUserGroupActionsAccess[action.code].visible}
+                                                    onChange={event =>
+                                                        updateUiUserGroupActionsAccess(
+                                                            action.code,
+                                                            "visible",
+                                                            event.target.checked
+                                                        )
+                                                    }
+                                                />
+                                            }
+                                            label={action.label}
+                                            key={action.code}
+                                        />
+                                    ))}
                                 </Box>
                             </AccordionDetails>
                         </Accordion>
@@ -295,20 +327,29 @@ export const PermissionsPage = React.memo((props: PermissionsPageProps) => {
                                     flexDirection="column"
                                     gridRowGap={theme.spacing(1)}
                                 >
-                                    {UI_USER_ROLE_ACTION_LIST.map(action => (
-                                        <FormControlLabel
-                                            control={
-                                                <Switch
-                                                    checked={formState.uiUserRoleActionsAccess[action.code].visible}
-                                                    onChange={event =>
-                                                        updateUiUserRoleActionsAccess(action.code, event.target.checked)
+                                    <Typography variant="h6">{i18n.t("Filters")}</Typography>
+                                    <FiltersGrid>
+                                        <FiltersGridHeader />
+                                        {UI_USER_ROLE_ACTION_LIST.map(action => {
+                                            const entry = formState.uiUserRoleActionsAccess[action.code];
+                                            const isBoolean = BOOLEAN_USER_ROLE_FILTERS.includes(action.code);
+                                            return (
+                                                <FilterRow
+                                                    key={action.code}
+                                                    label={action.label}
+                                                    visible={entry.visible}
+                                                    defaultValue={entry.defaultValue}
+                                                    isBoolean={isBoolean}
+                                                    onVisibleChange={v =>
+                                                        updateUiUserRoleActionsAccess(action.code, "visible", v)
+                                                    }
+                                                    onDefaultChange={v =>
+                                                        updateUiUserRoleActionsAccess(action.code, "defaultValue", v)
                                                     }
                                                 />
-                                            }
-                                            label={action.label}
-                                            key={action.code}
-                                        />
-                                    ))}
+                                            );
+                                        })}
+                                    </FiltersGrid>
                                 </Box>
                             </AccordionDetails>
                         </Accordion>
@@ -324,23 +365,29 @@ export const PermissionsPage = React.memo((props: PermissionsPageProps) => {
                                     flexDirection="column"
                                     gridRowGap={theme.spacing(1)}
                                 >
-                                    {UI_DASHBOARD_ACTION_LIST.map(action => (
-                                        <FormControlLabel
-                                            control={
-                                                <Switch
-                                                    checked={formState.uiDashboardActionsAccess[action.code].visible}
-                                                    onChange={event =>
-                                                        updateUiDashboardActionsAccess(
-                                                            action.code,
-                                                            event.target.checked
-                                                        )
+                                    <Typography variant="h6">{i18n.t("Filters")}</Typography>
+                                    <FiltersGrid>
+                                        <FiltersGridHeader />
+                                        {UI_DASHBOARD_ACTION_LIST.map(action => {
+                                            const entry = formState.uiDashboardActionsAccess[action.code];
+                                            const isBoolean = BOOLEAN_DASHBOARD_FILTERS.includes(action.code);
+                                            return (
+                                                <FilterRow
+                                                    key={action.code}
+                                                    label={action.label}
+                                                    visible={entry.visible}
+                                                    defaultValue={entry.defaultValue}
+                                                    isBoolean={isBoolean}
+                                                    onVisibleChange={v =>
+                                                        updateUiDashboardActionsAccess(action.code, "visible", v)
+                                                    }
+                                                    onDefaultChange={v =>
+                                                        updateUiDashboardActionsAccess(action.code, "defaultValue", v)
                                                     }
                                                 />
-                                            }
-                                            label={action.label}
-                                            key={action.code}
-                                        />
-                                    ))}
+                                            );
+                                        })}
+                                    </FiltersGrid>
                                 </Box>
                             </AccordionDetails>
                         </Accordion>
@@ -382,3 +429,49 @@ const sharingOptions = {
     externalSharing: false,
     permissionPicker: false,
 };
+
+const FiltersGrid: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <Box display="grid" gridTemplateColumns="1fr auto auto" alignItems="center" style={{ columnGap: 24, rowGap: 4 }}>
+        {children}
+    </Box>
+);
+
+const FiltersGridHeader: React.FC = () => (
+    <>
+        <span />
+        <Typography variant="caption" align="center">
+            {i18n.t("Visible")}
+        </Typography>
+        <Typography variant="caption" align="center">
+            {i18n.t("Value")}
+        </Typography>
+    </>
+);
+
+type FilterRowProps = {
+    label: string;
+    visible: boolean;
+    defaultValue?: boolean;
+    isBoolean: boolean;
+    onVisibleChange: (value: boolean) => void;
+    onDefaultChange: (value: boolean) => void;
+};
+
+const FilterRow: React.FC<FilterRowProps> = ({
+    label,
+    visible,
+    defaultValue,
+    isBoolean,
+    onVisibleChange,
+    onDefaultChange,
+}) => (
+    <>
+        <Typography component="span">{label}</Typography>
+        <Switch checked={visible} onChange={e => onVisibleChange(e.target.checked)} />
+        {isBoolean ? (
+            <Switch checked={defaultValue ?? true} onChange={e => onDefaultChange(e.target.checked)} />
+        ) : (
+            <Typography component="span" align="center" color="textSecondary"></Typography>
+        )}
+    </>
+);

--- a/src/webapp/components/permissions-page/usePermissionsPage.ts
+++ b/src/webapp/components/permissions-page/usePermissionsPage.ts
@@ -71,24 +71,45 @@ export const usePermissionsPage = (onSave: (appSettings: AppSettings) => void, p
         }));
     };
 
-    const updateUiUserGroupActionsAccess = (actionCode: UIUserGroupActionType, value: boolean) => {
+    const updateUiUserGroupActionsAccess = (
+        actionCode: UIUserGroupActionType,
+        field: "visible" | "defaultValue",
+        value: boolean
+    ) => {
         setForm(prev => ({
             ...prev,
-            uiUserGroupActionsAccess: { ...prev.uiUserGroupActionsAccess, [actionCode]: { visible: value } },
+            uiUserGroupActionsAccess: {
+                ...prev.uiUserGroupActionsAccess,
+                [actionCode]: { ...prev.uiUserGroupActionsAccess[actionCode], [field]: value },
+            },
         }));
     };
 
-    const updateUiUserRoleActionsAccess = (actionCode: UIUserRoleActionType, value: boolean) => {
+    const updateUiUserRoleActionsAccess = (
+        actionCode: UIUserRoleActionType,
+        field: "visible" | "defaultValue",
+        value: boolean
+    ) => {
         setForm(prev => ({
             ...prev,
-            uiUserRoleActionsAccess: { ...prev.uiUserRoleActionsAccess, [actionCode]: { visible: value } },
+            uiUserRoleActionsAccess: {
+                ...prev.uiUserRoleActionsAccess,
+                [actionCode]: { ...prev.uiUserRoleActionsAccess[actionCode], [field]: value },
+            },
         }));
     };
 
-    const updateUiDashboardActionsAccess = (actionCode: UIDashboardActionType, value: boolean) => {
+    const updateUiDashboardActionsAccess = (
+        actionCode: UIDashboardActionType,
+        field: "visible" | "defaultValue",
+        value: boolean
+    ) => {
         setForm(prev => ({
             ...prev,
-            uiDashboardActionsAccess: { ...prev.uiDashboardActionsAccess, [actionCode]: { visible: value } },
+            uiDashboardActionsAccess: {
+                ...prev.uiDashboardActionsAccess,
+                [actionCode]: { ...prev.uiDashboardActionsAccess[actionCode], [field]: value },
+            },
         }));
     };
 

--- a/src/webapp/components/user-group-table/UserGroupTable.tsx
+++ b/src/webapp/components/user-group-table/UserGroupTable.tsx
@@ -23,9 +23,10 @@ import { getFilename } from "../../utils/file";
 
 import { makeStyles } from "@material-ui/core";
 import { isSuperAdmin, UserProps } from "../../../domain/entities/UserProps";
-import { Maybe } from "../../../types/utils";
 import { AppSettings } from "../../../domain/entities/AppSettings";
 import { GroupColumnSetting } from "../../../domain/entities/GroupColumn";
+import { useUserGroups } from "./useUserGroups";
+import { createPagination, filterAndSortItemWithUsers } from "../../utils/table";
 
 function generateTableConfig(options: {
     currentPageSize: number;
@@ -69,7 +70,7 @@ export const UserGroupTable: React.FC<UserGroupTableProps> = React.memo(props =>
     const [filterEmptyUsers, setFilterEmptyUsers] = React.useState(true);
     const { compositionRoot, currentUser } = useAppContext();
     const classes = useStyles();
-    const { userGroups } = useGetAllUserGroups({ excludeUsersOutsideOrgUnits: excludeUsersOrgUnit, currentUser });
+    const { userGroups } = useUserGroups({ excludeUsersOutsideOrgUnits: excludeUsersOrgUnit, currentUser });
     const isAdmin = isSuperAdmin(currentUser);
     const [columnsPreference, setColumnsPreference] = React.useState<GroupColumnSetting[]>([]);
 
@@ -106,8 +107,8 @@ export const UserGroupTable: React.FC<UserGroupTableProps> = React.memo(props =>
         ): Promise<{ objects: UserGroup[]; pager: Pager }> => {
             setCurrentPageSize(pageSize);
 
-            const filteredUserGroups = filterAndSortUserGroups({
-                groups: userGroups,
+            const filteredUserGroups = filterAndSortItemWithUsers({
+                items: userGroups,
                 search: search,
                 sort: sorting.order,
                 filterEmptyUsers: filterEmptyUsers,
@@ -179,22 +180,6 @@ const useStyles = makeStyles({
     },
 });
 
-function useGetAllUserGroups(props: { excludeUsersOutsideOrgUnits: boolean; currentUser: UserProps }): {
-    userGroups: UserGroup[];
-} {
-    const { currentUser, excludeUsersOutsideOrgUnits } = props;
-    const { compositionRoot } = useAppContext();
-    const [userGroups, setUserGroups] = React.useState<UserGroup[]>([]);
-
-    React.useEffect(() => {
-        return compositionRoot.userGroups
-            .get({ excludeUsersOutsideOrgUnits, user: currentUser })
-            .run(setUserGroups, console.error);
-    }, [compositionRoot.userGroups, currentUser, excludeUsersOutsideOrgUnits]);
-
-    return { userGroups };
-}
-
 function buildCsvRow(rows: UserGroup[], fileName: string): void {
     FileSaver.saveAs(
         new Blob(
@@ -207,49 +192,4 @@ function buildCsvRow(rows: UserGroup[], fileName: string): void {
         ),
         fileName
     );
-}
-
-export const filterAndSortUserGroups = (options: {
-    groups: UserGroup[];
-    search: string;
-    sort: "asc" | "desc";
-    filterEmptyUsers: boolean;
-    selectedUsersIds: Maybe<Id[]>;
-}): UserGroup[] => {
-    const { groups, search, sort = "asc", filterEmptyUsers, selectedUsersIds } = options;
-    const filtered = _(groups)
-        .filter(group => {
-            const { name, users } = group;
-
-            const matchesSearch = search ? name.toLowerCase().includes(search.toLowerCase()) : true;
-
-            const matchesUsers =
-                selectedUsersIds && selectedUsersIds.length > 0
-                    ? users.some(user => selectedUsersIds.includes(user.id))
-                    : true;
-
-            return matchesSearch && matchesUsers;
-        })
-        .filter(group => {
-            if (!filterEmptyUsers) return true;
-            return group.users.length > 0;
-        })
-        .orderBy(dashboard => dashboard.name, sort)
-        .value();
-
-    return filtered;
-};
-
-function createPagination<T>(records: T[], page: number, pageSize: number): { objects: T[]; pager: Pager } {
-    const pager: Pager = {
-        page: page,
-        pageCount: Math.ceil(records.length / pageSize),
-        total: records.length,
-        pageSize: pageSize,
-    };
-
-    const startIndex = (page - 1) * pageSize;
-    const endIndex = startIndex + pageSize;
-    const pagedRecords = records.slice(startIndex, endIndex);
-    return { objects: pagedRecords, pager };
 }

--- a/src/webapp/components/user-group-table/UserGroupTable.tsx
+++ b/src/webapp/components/user-group-table/UserGroupTable.tsx
@@ -163,6 +163,7 @@ export const UserGroupTable: React.FC<UserGroupTableProps> = React.memo(props =>
                     showUserFilter={isAdmin || appSettings.uiUserGroupActionsAccess.filterUsers.visible}
                     showOrgUnitFilter={isAdmin || appSettings.uiUserGroupActionsAccess.filterUsersInOrgUnit.visible}
                     filterUserLabel={i18n.t("Filter users")}
+                    emptyUsersLabel={i18n.t("Hide not applicable user groups")} 
                     showEmptyUsers={
                         isAdmin || appSettings.uiUserGroupActionsAccess.filterHideNotApplicableUserGroups.visible
                     }

--- a/src/webapp/components/user-group-table/UserGroupTable.tsx
+++ b/src/webapp/components/user-group-table/UserGroupTable.tsx
@@ -64,10 +64,13 @@ type UserGroupTableProps = {
 
 export const UserGroupTable: React.FC<UserGroupTableProps> = React.memo(props => {
     const { appSettings } = props;
+    const defaultExcludeOrgUnit = appSettings.uiUserGroupActionsAccess.filterUsersInOrgUnit.defaultValue ?? true;
+    const defaultFilterEmptyUsers =
+        appSettings.uiUserGroupActionsAccess.filterHideNotApplicableUserGroups.defaultValue ?? true;
     const [currentPageSize, setCurrentPageSize] = React.useState(25);
     const [selectedUsersIds, setSelectedUsersIds] = React.useState<Id[]>();
-    const [excludeUsersOrgUnit, setExcludeUsersOrgUnit] = React.useState(true);
-    const [filterEmptyUsers, setFilterEmptyUsers] = React.useState(true);
+    const [excludeUsersOrgUnit, setExcludeUsersOrgUnit] = React.useState(defaultExcludeOrgUnit);
+    const [filterEmptyUsers, setFilterEmptyUsers] = React.useState(defaultFilterEmptyUsers);
     const { compositionRoot, currentUser } = useAppContext();
     const classes = useStyles();
     const { userGroups } = useUserGroups({ excludeUsersOutsideOrgUnits: excludeUsersOrgUnit, currentUser });
@@ -163,6 +166,8 @@ export const UserGroupTable: React.FC<UserGroupTableProps> = React.memo(props =>
                     showEmptyUsers={
                         isAdmin || appSettings.uiUserGroupActionsAccess.filterHideNotApplicableUserGroups.visible
                     }
+                    defaultExcludeOrgUnit={defaultExcludeOrgUnit}
+                    defaultFilterEmptyUsers={defaultFilterEmptyUsers}
                 />
             )}
             {items.length > 0 && (

--- a/src/webapp/components/user-group-table/useUserGroups.ts
+++ b/src/webapp/components/user-group-table/useUserGroups.ts
@@ -1,0 +1,20 @@
+import { UserGroup } from "../../../domain/entities/UserGroup";
+import { UserProps } from "../../../domain/entities/UserProps";
+import { useAppContext } from "../../contexts/app-context";
+import React from "react";
+
+export function useUserGroups(props: { excludeUsersOutsideOrgUnits: boolean; currentUser: UserProps }): {
+    userGroups: UserGroup[];
+} {
+    const { currentUser, excludeUsersOutsideOrgUnits } = props;
+    const { compositionRoot } = useAppContext();
+    const [userGroups, setUserGroups] = React.useState<UserGroup[]>([]);
+
+    React.useEffect(() => {
+        return compositionRoot.userGroups
+            .get({ excludeUsersOutsideOrgUnits, user: currentUser })
+            .run(setUserGroups, console.error);
+    }, [compositionRoot.userGroups, currentUser, excludeUsersOutsideOrgUnits]);
+
+    return { userGroups };
+}

--- a/src/webapp/components/user-role/UserRoleTable.tsx
+++ b/src/webapp/components/user-role/UserRoleTable.tsx
@@ -19,7 +19,7 @@ import { RoleColumnSetting } from "../../../domain/entities/RoleColumn";
 import { isSuperAdmin, UserProps } from "../../../domain/entities/UserProps";
 import { AppSettings } from "../../../domain/entities/AppSettings";
 import { useUserRoles } from "./useUserRoles";
-import { Maybe } from "../../../types/utils";
+import { createPagination, filterAndSortItemWithUsers } from "../../utils/table";
 
 function generateTableConfig(
     currentPageSize: number,
@@ -75,8 +75,8 @@ export const UserRoleTable: React.FC<{ appSettings: AppSettings }> = React.memo(
         ): Promise<{ objects: UserRole[]; pager: Pager }> => {
             setCurrentPageSize(pageSize);
 
-            const filteredUserRoles = filterAndSortUserRoles({
-                roles: userRoles,
+            const filteredUserRoles = filterAndSortItemWithUsers({
+                items: userRoles,
                 search: search,
                 sort: sorting.order,
                 filterEmptyUsers: filterEmptyUsers,
@@ -118,48 +118,3 @@ export const UserRoleTable: React.FC<{ appSettings: AppSettings }> = React.memo(
         </ObjectsList>
     );
 });
-
-export const filterAndSortUserRoles = (options: {
-    roles: UserRole[];
-    search: string;
-    sort: "asc" | "desc";
-    filterEmptyUsers: boolean;
-    selectedUsersIds: Maybe<Id[]>;
-}): UserRole[] => {
-    const { roles, search, sort = "asc", filterEmptyUsers, selectedUsersIds } = options;
-    const filtered = _(roles)
-        .filter(role => {
-            const { name, users } = role;
-
-            const matchesSearch = search ? name.toLowerCase().includes(search.toLowerCase()) : true;
-
-            const matchesUsers =
-                selectedUsersIds && selectedUsersIds.length > 0
-                    ? users.some(user => selectedUsersIds.includes(user.id))
-                    : true;
-
-            return matchesSearch && matchesUsers;
-        })
-        .filter(role => {
-            if (!filterEmptyUsers) return true;
-            return role.users.length > 0;
-        })
-        .orderBy(role => role.name, sort)
-        .value();
-
-    return filtered;
-};
-
-function createPagination<T>(records: T[], page: number, pageSize: number): { objects: T[]; pager: Pager } {
-    const pager: Pager = {
-        page: page,
-        pageCount: Math.ceil(records.length / pageSize),
-        total: records.length,
-        pageSize: pageSize,
-    };
-
-    const startIndex = (page - 1) * pageSize;
-    const endIndex = startIndex + pageSize;
-    const pagedRecords = records.slice(startIndex, endIndex);
-    return { objects: pagedRecords, pager };
-}

--- a/src/webapp/components/user-role/UserRoleTable.tsx
+++ b/src/webapp/components/user-role/UserRoleTable.tsx
@@ -51,10 +51,13 @@ function generateTableConfig(
 
 export const UserRoleTable: React.FC<{ appSettings: AppSettings }> = React.memo(props => {
     const { appSettings } = props;
+    const defaultExcludeOrgUnit = appSettings.uiUserRoleActionsAccess.filterUsersInOrgUnit.defaultValue ?? true;
+    const defaultFilterEmptyUsers =
+        appSettings.uiUserRoleActionsAccess.filterHideNotApplicableUserRoles.defaultValue ?? true;
     const { compositionRoot, currentUser } = useAppContext();
     const [userIds, setUserIds] = React.useState<Id[]>();
-    const [excludeUsersOrgUnit, setExcludeUsersOrgUnit] = React.useState(true);
-    const [filterEmptyUsers, setFilterEmptyUsers] = React.useState(true);
+    const [excludeUsersOrgUnit, setExcludeUsersOrgUnit] = React.useState(defaultExcludeOrgUnit);
+    const [filterEmptyUsers, setFilterEmptyUsers] = React.useState(defaultFilterEmptyUsers);
     const [columnsPreference, setColumnsPreference] = React.useState<RoleColumnSetting[]>([]);
     const { userRoles } = useUserRoles({ excludeUsersOutsideOrgUnits: excludeUsersOrgUnit, currentUser });
     const [currentPageSize, setCurrentPageSize] = React.useState(25);
@@ -113,6 +116,8 @@ export const UserRoleTable: React.FC<{ appSettings: AppSettings }> = React.memo(
                     showEmptyUsers={
                         isAdmin || appSettings.uiUserRoleActionsAccess.filterHideNotApplicableUserRoles.visible
                     }
+                    defaultExcludeOrgUnit={defaultExcludeOrgUnit}
+                    defaultFilterEmptyUsers={defaultFilterEmptyUsers}
                 />
             )}
         </ObjectsList>

--- a/src/webapp/components/user-role/UserRoleTable.tsx
+++ b/src/webapp/components/user-role/UserRoleTable.tsx
@@ -18,8 +18,14 @@ import { Id } from "../../../domain/entities/Ref";
 import { RoleColumnSetting } from "../../../domain/entities/RoleColumn";
 import { isSuperAdmin, UserProps } from "../../../domain/entities/UserProps";
 import { AppSettings } from "../../../domain/entities/AppSettings";
+import { useUserRoles } from "./useUserRoles";
+import { Maybe } from "../../../types/utils";
 
-function generateTableConfig(roleColumns: RoleColumnSetting[], currentUser: UserProps): TableConfig<UserRole> {
+function generateTableConfig(
+    currentPageSize: number,
+    roleColumns: RoleColumnSetting[],
+    currentUser: UserProps
+): TableConfig<UserRole> {
     const allColumns: TableColumn<UserRole>[] = roleColumns.map(columnSetting => {
         return {
             name: columnSetting.fieldName,
@@ -39,7 +45,7 @@ function generateTableConfig(roleColumns: RoleColumnSetting[], currentUser: User
         actions: [],
         columns: allColumns,
         initialSorting: { field: "name", order: "asc" },
-        paginationOptions: { pageSizeInitialValue: 25, pageSizeOptions: [10, 25, 50] },
+        paginationOptions: { pageSizeInitialValue: currentPageSize, pageSizeOptions: [10, 25, 50] },
     };
 }
 
@@ -48,15 +54,18 @@ export const UserRoleTable: React.FC<{ appSettings: AppSettings }> = React.memo(
     const { compositionRoot, currentUser } = useAppContext();
     const [userIds, setUserIds] = React.useState<Id[]>();
     const [excludeUsersOrgUnit, setExcludeUsersOrgUnit] = React.useState(true);
+    const [filterEmptyUsers, setFilterEmptyUsers] = React.useState(true);
     const [columnsPreference, setColumnsPreference] = React.useState<RoleColumnSetting[]>([]);
+    const { userRoles } = useUserRoles({ excludeUsersOutsideOrgUnits: excludeUsersOrgUnit, currentUser });
+    const [currentPageSize, setCurrentPageSize] = React.useState(25);
 
     React.useEffect(() => {
         return compositionRoot.roleColumns.get.execute(currentUser).run(setColumnsPreference, console.error);
     }, [compositionRoot.roleColumns, currentUser, appSettings]);
 
     const config = React.useMemo(() => {
-        return generateTableConfig(columnsPreference, currentUser);
-    }, [columnsPreference, currentUser]);
+        return generateTableConfig(currentPageSize, columnsPreference, currentUser);
+    }, [currentPageSize, columnsPreference, currentUser]);
 
     const getRows = React.useCallback(
         (
@@ -64,19 +73,19 @@ export const UserRoleTable: React.FC<{ appSettings: AppSettings }> = React.memo(
             { page, pageSize }: TablePagination,
             sorting: TableSorting<UserRole>
         ): Promise<{ objects: UserRole[]; pager: Pager }> => {
-            return compositionRoot.userRoles
-                .get({
-                    page: page,
-                    pageSize: pageSize,
-                    search: search,
-                    sorting: { field: sorting.field, order: sorting.order },
-                    excludeUsersOutsideOrgUnits: excludeUsersOrgUnit,
-                    user: currentUser,
-                    userIds: userIds,
-                })
-                .toPromise();
+            setCurrentPageSize(pageSize);
+
+            const filteredUserRoles = filterAndSortUserRoles({
+                roles: userRoles,
+                search: search,
+                sort: sorting.order,
+                filterEmptyUsers: filterEmptyUsers,
+                selectedUsersIds: userIds,
+            });
+
+            return Promise.resolve(createPagination(filteredUserRoles, page, pageSize));
         },
-        [compositionRoot.userRoles, currentUser, excludeUsersOrgUnit, userIds]
+        [userRoles, filterEmptyUsers, userIds]
     );
 
     const tableProps = useObjectsTable(config, getRows);
@@ -84,6 +93,7 @@ export const UserRoleTable: React.FC<{ appSettings: AppSettings }> = React.memo(
     const updateFilters = React.useCallback<UsersFiltersProps["onFilterChange"]>(filters => {
         setExcludeUsersOrgUnit(filters.excludeOutsideOrgUnit);
         setUserIds(filters.users.map(user => user.value));
+        setFilterEmptyUsers(filters.filterEmptyUsers);
     }, []);
 
     const isAdmin = isSuperAdmin(currentUser);
@@ -100,8 +110,56 @@ export const UserRoleTable: React.FC<{ appSettings: AppSettings }> = React.memo(
                     showOrgUnitFilter={isAdmin || appSettings.uiUserRoleActionsAccess.filterUsersInOrgUnit.visible}
                     showUserFilter={isAdmin || appSettings.uiUserRoleActionsAccess.filterUsers.visible}
                     filterUserLabel={i18n.t("Filter users")}
+                    showEmptyUsers={
+                        isAdmin || appSettings.uiUserRoleActionsAccess.filterHideNotApplicableUserRoles.visible
+                    }
                 />
             )}
         </ObjectsList>
     );
 });
+
+export const filterAndSortUserRoles = (options: {
+    roles: UserRole[];
+    search: string;
+    sort: "asc" | "desc";
+    filterEmptyUsers: boolean;
+    selectedUsersIds: Maybe<Id[]>;
+}): UserRole[] => {
+    const { roles, search, sort = "asc", filterEmptyUsers, selectedUsersIds } = options;
+    const filtered = _(roles)
+        .filter(role => {
+            const { name, users } = role;
+
+            const matchesSearch = search ? name.toLowerCase().includes(search.toLowerCase()) : true;
+
+            const matchesUsers =
+                selectedUsersIds && selectedUsersIds.length > 0
+                    ? users.some(user => selectedUsersIds.includes(user.id))
+                    : true;
+
+            return matchesSearch && matchesUsers;
+        })
+        .filter(role => {
+            if (!filterEmptyUsers) return true;
+            return role.users.length > 0;
+        })
+        .orderBy(role => role.name, sort)
+        .value();
+
+    return filtered;
+};
+
+function createPagination<T>(records: T[], page: number, pageSize: number): { objects: T[]; pager: Pager } {
+    const pager: Pager = {
+        page: page,
+        pageCount: Math.ceil(records.length / pageSize),
+        total: records.length,
+        pageSize: pageSize,
+    };
+
+    const startIndex = (page - 1) * pageSize;
+    const endIndex = startIndex + pageSize;
+    const pagedRecords = records.slice(startIndex, endIndex);
+    return { objects: pagedRecords, pager };
+}

--- a/src/webapp/components/user-role/UserRoleTable.tsx
+++ b/src/webapp/components/user-role/UserRoleTable.tsx
@@ -113,6 +113,7 @@ export const UserRoleTable: React.FC<{ appSettings: AppSettings }> = React.memo(
                     showOrgUnitFilter={isAdmin || appSettings.uiUserRoleActionsAccess.filterUsersInOrgUnit.visible}
                     showUserFilter={isAdmin || appSettings.uiUserRoleActionsAccess.filterUsers.visible}
                     filterUserLabel={i18n.t("Filter users")}
+                    emptyUsersLabel={i18n.t("Hide not applicable user roles")}
                     showEmptyUsers={
                         isAdmin || appSettings.uiUserRoleActionsAccess.filterHideNotApplicableUserRoles.visible
                     }

--- a/src/webapp/components/user-role/useUserRoles.ts
+++ b/src/webapp/components/user-role/useUserRoles.ts
@@ -1,0 +1,20 @@
+import { UserProps } from "../../../domain/entities/UserProps";
+import { UserRole } from "../../../domain/entities/UserRole";
+import { useAppContext } from "../../contexts/app-context";
+import React from "react";
+
+export function useUserRoles(props: { excludeUsersOutsideOrgUnits: boolean; currentUser: UserProps }): {
+    userRoles: UserRole[];
+} {
+    const { currentUser, excludeUsersOutsideOrgUnits } = props;
+    const { compositionRoot } = useAppContext();
+    const [userRoles, setUserRoles] = React.useState<UserRole[]>([]);
+
+    React.useEffect(() => {
+        return compositionRoot.userRoles
+            .get({ excludeUsersOutsideOrgUnits, user: currentUser })
+            .run(setUserRoles, console.error);
+    }, [compositionRoot.userRoles, currentUser, excludeUsersOutsideOrgUnits]);
+
+    return { userRoles };
+}

--- a/src/webapp/components/users-filter/UsersFilters.tsx
+++ b/src/webapp/components/users-filter/UsersFilters.tsx
@@ -21,15 +21,25 @@ export type UsersFiltersProps = {
     showOrgUnitFilter?: boolean;
     filterUserLabel?: string;
     showEmptyUsers?: boolean;
+    defaultExcludeOrgUnit?: boolean;
+    defaultFilterEmptyUsers?: boolean;
 };
 
 export const UsersFilters: React.FC<UsersFiltersProps> = React.memo(props => {
-    const { onFilterChange, showUserFilter, showOrgUnitFilter, filterUserLabel = "", showEmptyUsers } = props;
+    const {
+        onFilterChange,
+        showUserFilter,
+        showOrgUnitFilter,
+        filterUserLabel = "",
+        showEmptyUsers,
+        defaultExcludeOrgUnit = true,
+        defaultFilterEmptyUsers = true,
+    } = props;
 
-    const [filterEmptyUsers, setFilterEmptyUsers] = React.useState(true);
+    const [filterEmptyUsers, setFilterEmptyUsers] = React.useState(defaultFilterEmptyUsers);
     const [showUserFilterModal, setShowUserFilterModal] = React.useState(false);
     const [openFilterDialog, setOpenFilterDialog] = React.useState(false);
-    const [excludeOrgUnit, setExcludeOrgUnit] = React.useState(true);
+    const [excludeOrgUnit, setExcludeOrgUnit] = React.useState(defaultExcludeOrgUnit);
     const [ids, selectedIds] = React.useState<Id[]>([]);
     const { users } = useGetUsersSimple({
         enabled: showUserFilter ?? false,

--- a/src/webapp/components/users-filter/UsersFilters.tsx
+++ b/src/webapp/components/users-filter/UsersFilters.tsx
@@ -31,7 +31,10 @@ export const UsersFilters: React.FC<UsersFiltersProps> = React.memo(props => {
     const [openFilterDialog, setOpenFilterDialog] = React.useState(false);
     const [excludeOrgUnit, setExcludeOrgUnit] = React.useState(true);
     const [ids, selectedIds] = React.useState<Id[]>([]);
-    const { users } = useGetUsersSimple({ enabled: showUserFilter ?? false });
+    const { users } = useGetUsersSimple({
+        enabled: showUserFilter ?? false,
+        restrictToOrgUnits: excludeOrgUnit,
+    });
 
     const openUserFilterModal = React.useCallback(() => {
         if (users && users?.length > 0) {
@@ -163,20 +166,23 @@ export const UsersFilters: React.FC<UsersFiltersProps> = React.memo(props => {
     );
 });
 
-export function useGetUsersSimple(props: { enabled: boolean }) {
-    const { enabled } = props;
+export function useGetUsersSimple(props: { enabled: boolean; restrictToOrgUnits: boolean }) {
+    const { enabled, restrictToOrgUnits } = props;
     const { compositionRoot, currentUser } = useAppContext();
     const [users, setUsers] = React.useState<UserSimple[]>([]);
 
     React.useEffect(() => {
         if (!enabled) return;
-        return compositionRoot.users.getInOrgUnits(currentUser).run(
-            users => {
-                setUsers(users);
+        const future = restrictToOrgUnits
+            ? compositionRoot.users.getInOrgUnits(currentUser)
+            : compositionRoot.users.getAllSimple(currentUser);
+        return future.run(
+            loadedUsers => {
+                setUsers(loadedUsers);
             },
             error => console.error(error)
         );
-    }, [compositionRoot.users, currentUser, enabled]);
+    }, [compositionRoot.users, currentUser, enabled, restrictToOrgUnits]);
 
     return { users };
 }

--- a/src/webapp/components/users-filter/UsersFilters.tsx
+++ b/src/webapp/components/users-filter/UsersFilters.tsx
@@ -20,6 +20,7 @@ export type UsersFiltersProps = {
     showOwnerFilter?: boolean;
     showOrgUnitFilter?: boolean;
     filterUserLabel?: string;
+    emptyUsersLabel?: string;
     showEmptyUsers?: boolean;
     defaultExcludeOrgUnit?: boolean;
     defaultFilterEmptyUsers?: boolean;
@@ -31,6 +32,7 @@ export const UsersFilters: React.FC<UsersFiltersProps> = React.memo(props => {
         showUserFilter,
         showOrgUnitFilter,
         filterUserLabel = "",
+        emptyUsersLabel = i18n.t("Hide not applicable user groups"),
         showEmptyUsers,
         defaultExcludeOrgUnit = true,
         defaultFilterEmptyUsers = true,
@@ -127,7 +129,7 @@ export const UsersFilters: React.FC<UsersFiltersProps> = React.memo(props => {
                                     onChange={e => setFilterEmptyUsers(e.target.checked)}
                                 />
                             }
-                            label={i18n.t("Hide not applicable user groups")}
+                            label={emptyUsersLabel}
                         />
                     )}
 

--- a/src/webapp/utils/table.ts
+++ b/src/webapp/utils/table.ts
@@ -1,0 +1,49 @@
+import { Maybe } from "../../types/utils";
+import { Id } from "../../domain/entities/Ref";
+import _ from "lodash";
+import { Pager } from "../../domain/entities/PaginatedResponse";
+
+export function filterAndSortItemWithUsers<T extends { name: string; users: { id: string }[] }>(options: {
+    items: T[];
+    search: string;
+    sort: "asc" | "desc";
+    filterEmptyUsers: boolean;
+    selectedUsersIds: Maybe<Id[]>;
+}): T[] {
+    const { items, search, sort = "asc", filterEmptyUsers, selectedUsersIds } = options;
+    const filtered = _(items)
+        .filter(item => {
+            const { name, users } = item;
+
+            const matchesSearch = search ? name.toLowerCase().includes(search.toLowerCase()) : true;
+
+            const matchesUsers =
+                selectedUsersIds && selectedUsersIds.length > 0
+                    ? users.some(user => selectedUsersIds.includes(user.id))
+                    : true;
+
+            return matchesSearch && matchesUsers;
+        })
+        .filter(item => {
+            if (!filterEmptyUsers) return true;
+            return item.users.length > 0;
+        })
+        .orderBy(item => item.name, sort)
+        .value();
+
+    return filtered;
+}
+
+export function createPagination<T>(records: T[], page: number, pageSize: number): { objects: T[]; pager: Pager } {
+    const pager: Pager = {
+        page: page,
+        pageCount: Math.ceil(records.length / pageSize),
+        total: records.length,
+        pageSize: pageSize,
+    };
+
+    const startIndex = (page - 1) * pageSize;
+    const endIndex = startIndex + pageSize;
+    const pagedRecords = records.slice(startIndex, endIndex);
+    return { objects: pagedRecords, pager };
+}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes  https://app.clickup.com/t/869c4afga #869c4afga

### :memo: Implementation                                                                                                                                                                            
                                                                                                                                                                                                       
  This branch consolidates several changes to the **User Groups**, **User Roles** and **Dashboards** tabs, both in behaviour and in App Settings.                                                      
                                                                                                                                                                                                       
  **1. Hide "Filter by Users" column in DHIS2 2.42** (`3ba477e`)
                                                                                                                                                                                                       
  DHIS2 2.42 moved several user properties out of `userCredentials`. The "Filter by Users" column and related filter is now hidden on 2.42 instances where the filtering contract is incompatible,
  avoiding broken queries.                                                                                                                                                                             
                                                            
  **2. Add Hide not applicable user roles filter** (`d57f97b`)                                                                                                                           
                                                            
  User Roles tab now mirrors User Groups behaviour: after filtering users by the current org unit scope, roles with no remaining users are hidden in memory when "Hide not applicable user roles" is   
  enabled. Previously this only worked via API for User Groups.

  **3. Shared implementation between User Roles and User Groups** (`c2890be`)                                                                                                                          
                                          
  Refactor to remove duplicated filtering / org-unit scoping logic between the two tabs, so they now share the same code paths.                                                                        
                                                                                                                                                                                                       
  **4. Load all users when org-unit scope is disabled in users filter** (`cb4c056`)
                                                                                                                                                                                                       
  When the "Show only users assigned to my organization unit and below" toggle is **off**, the "Filter by Users" dropdown now fetches **all** users via a new `GetAllUsersSimpleUseCase`, so the admin
  can filter by users outside the current scope.                                                                                                                                                       
                                                            
  **5. Configurable default value for boolean filters in App Settings** (`fef5a3d`)                                                                                                                    
   
  App Settings → **Filter Permissions** can now configure, per tab (User Groups / User Roles / Dashboards), not only **Visible** but also **Default** for the boolean filters:                         
  - `filterUsersInOrgUnit` (all three tabs)                 
  - `filterHideNotApplicableUserGroups` / `filterHideNotApplicableUserRoles`
                                                                                                                                                                                                       
  The `Show/Hide Filters` section is renamed to `Filters` and uses a two-column `Visible | Default` layout. `Visible` and `Default` are independent — the admin can pre-configure the default state
  even when the filter is hidden from non-admin users. Defaults apply to admin and non-admin alike.                                                                                                    
                                                                                                                                                                                                       
  On the data layer, `appSettingsHelpers.mergeAndAddRuntimeProps` was refactored into a single generic `migrateRecord` helper that back-fills missing keys and missing fields from defaults. This      
  replaces the previous `migrateNewerActions` and merge logic, and covers forward-compatible migration for both class-based (`actionsAccess`) and plain-object records (`uiXxxActionsAccess`). Unit    
  tests added in `src/data/repositories/common/__tests__/appSettingsHelpers.spec.ts`.                                                                                                                  
                                                                                                                                                                                                       
  ### :video_camera: Screenshots/Screen capture
                                                                                                                                                                                                       
App settings Before
<img width="1900" height="930" alt="Screenshot 2026-04-15 at 10 19 41" src="https://github.com/user-attachments/assets/733151e4-7a69-47e5-882e-e52721050dd6" />


App settings After
<img width="1918" height="931" alt="Screenshot 2026-04-15 at 10 18 22" src="https://github.com/user-attachments/assets/a5480a53-8fa1-4064-989c-58d046aeac3f" />

                                              
  ### :fire: Testing                      
                                              
  1. Open the app as **admin** and go to **Settings → Filter Permissions**.                                                                                                                            
  2. Expand each accordion (User Groups, User Roles, Dashboards) and verify:
      - The section is titled **Filters** and shows two columns **Visible | Default**.                                                                                                                 
      - Boolean filters (`Show only users assigned...`, `Hide not applicable...`) have both switches.
      - Non-boolean rows (`Filter by Users`, `Filter by Owners`, exports) show only **Visible**, with `—` under Default.                                                                               
  3. Toggle `Show only users assigned to my org unit and below` **Default = OFF** in User Groups and save.                                                                                             
  4. Go to the **User Groups** tab and verify the filter opens already unchecked and the full user-group list (beyond the admin's org units) is displayed.                                             
  5. Repeat step 3–4 for **User Roles** and **Dashboards**.                                                                                                                                            
  6. Set `filterUsersInOrgUnit.visible = false` but `defaultValue = false` and save. Log in as a **non-admin** user and verify:                                                                        
      - The toggle is not visible in the User Groups / User Roles / Dashboards tab.                                                                                                                    
      - The list loads **without** the org-unit scope applied (hidden default is honoured).                                                                                                            
  7. With `Default = ON`, open the User Roles tab on a DHIS2 2.42 instance and verify:                                                                                                                 
      - Roles with no users from the current org unit scope are hidden when "Hide not applicable user roles" is active.                                                                                
      - Disabling the org-unit toggle loads the full user list in the "Filter by Users" dropdown.                                                                                                      
  8. Run `yarn test` — the new `appSettingsHelpers.spec.ts` suite (6 cases) must pass.                                                                                                                 
  9. Verify backward compatibility: on an instance with App Settings already stored **without** `defaultValue`, reload the app and confirm nothing breaks (missing `defaultValue` is back-filled to    
  `true` by `migrateRecord`).    
