### PR TITLE
[feature]: Re-enable strict username validation

### DIFF
--- a/src/domain/entities/User.ts
+++ b/src/domain/entities/User.ts
@@ -59,7 +59,7 @@ export class User extends Struct<UserProps>() {
                 processedProps.surname,
                 validateRequired(processedProps.surname, "Surname is required")
             ),
-            extractErrorFromEither("username", props.username, Username.create(props.username)),
+            extractErrorFromEither("username", props.username, Username.create(props.username, isExistingUser)),
             extractErrorFromEither("password", props.password, Password.create(props.password, isExistingUser)),
         ];
 

--- a/src/domain/entities/__tests__/Users.spec.ts
+++ b/src/domain/entities/__tests__/Users.spec.ts
@@ -220,7 +220,7 @@ describe("User Entity", () => {
                 });
             });
 
-            it.skip("should throw error when username contains invalid characters", () => {
+            it("should throw error when username contains invalid characters", () => {
                 const propsWithInvalidUsername = { ...validUserProps, username: "john#doe" };
 
                 const userResult = User.createNew(propsWithInvalidUsername);

--- a/src/domain/value-objects/Username.ts
+++ b/src/domain/value-objects/Username.ts
@@ -37,11 +37,7 @@ export class Username extends ValueObject<UsernameProps> {
         // unreadable/uneditable through this app.
         const charError = isExistingUser
             ? undefined
-            : validateRegexp(
-                  value,
-                  /^[a-zA-Z0-9._@-]+$/,
-                  "Username can only include . _ - or @ as separators"
-              );
+            : validateRegexp(value, /^[a-zA-Z0-9._@-]+$/, "Username can only include . _ - or @ as separators");
 
         const minLengthError = validateLengthMin(value, 2, "Username should be at least 2 characters long");
         const maxLengthError = validateLengthMax(value, 255, "Username may not exceed 255 characters");

--- a/src/domain/value-objects/Username.ts
+++ b/src/domain/value-objects/Username.ts
@@ -1,5 +1,11 @@
 import { Either } from "../entities/Either";
-import { validateLengthMax, validateLengthMin, validateNotRegexp, validateRequired } from "../utils/validations";
+import {
+    validateLengthMax,
+    validateLengthMin,
+    validateNotRegexp,
+    validateRegexp,
+    validateRequired,
+} from "../utils/validations";
 import { ValueObject } from "./ValueObject";
 
 export interface UsernameProps {
@@ -15,7 +21,7 @@ export class Username extends ValueObject<UsernameProps> {
         this.value = props.value;
     }
 
-    public static create(value: string): Either<string[], Username> {
+    public static create(value: string, isExistingUser = false): Either<string[], Username> {
         const requiredError = validateRequired(value, "Please provide a username");
 
         if (requiredError) {
@@ -25,19 +31,22 @@ export class Username extends ValueObject<UsernameProps> {
         const startError = validateNotRegexp(value, /^[._@-]|[._@-]$/, "Username cannot start or end with a separator");
         const doubleError = validateNotRegexp(value, /([._@-]){2,}/, "Username cannot have two separators in a row");
 
-        // Check Username.spec.ts ("character validation") for further explanation
-        // about why this validation is skipped
-
-        // const charError = validateRegexp(
-        //     value,
-        //     /^[a-zA-Z0-9._@-]+$/,
-        //     "Username can only include . _ - or @ as separators"
-        // );
+        // Existing users skip the character-set check: DHIS2 itself accepts
+        // characters outside this set, so legacy accounts already in the
+        // database may contain them — blocking here would make those users
+        // unreadable/uneditable through this app.
+        const charError = isExistingUser
+            ? undefined
+            : validateRegexp(
+                  value,
+                  /^[a-zA-Z0-9._@-]+$/,
+                  "Username can only include . _ - or @ as separators"
+              );
 
         const minLengthError = validateLengthMin(value, 2, "Username should be at least 2 characters long");
         const maxLengthError = validateLengthMax(value, 255, "Username may not exceed 255 characters");
 
-        const errors = [startError, doubleError, minLengthError, maxLengthError].filter(
+        const errors = [startError, doubleError, charError, minLengthError, maxLengthError].filter(
             error => error !== undefined
         ) as string[];
 
@@ -45,6 +54,6 @@ export class Username extends ValueObject<UsernameProps> {
             return Either.error(errors);
         }
 
-        return Either.success(new Username({ value: value }));
+        return Either.success(new Username({ value }));
     }
 }

--- a/src/domain/value-objects/__tests__/Username.spec.ts
+++ b/src/domain/value-objects/__tests__/Username.spec.ts
@@ -268,12 +268,7 @@ describe("Username value object", () => {
             });
         });
 
-        /* 
-           In the USERS app they have this validation rule, but the API allows these characters
-           and since we have already existing users that use them, we cannot apply this validation
-           so I'm skipping it for future reference
-        */
-        describe.skip("character validation", () => {
+        describe("character validation", () => {
             it("should return error when username contains invalid characters", () => {
                 const result = Username.create("john#doe");
 
@@ -326,12 +321,72 @@ describe("Username value object", () => {
                 });
             });
 
+            it("should return error when username contains a forward slash", () => {
+                const result = Username.create("john/doe");
+
+                result.match({
+                    error: errors => {
+                        expect(errors).toContain("Username can only include . _ - or @ as separators");
+                    },
+                    success: () => {
+                        throw new Error("Expected username validation to fail but it succeeded");
+                    },
+                });
+            });
+
             it("should return error when username contains special characters", () => {
                 const result = Username.create("john&doe*test");
 
                 result.match({
                     error: errors => {
                         expect(errors).toContain("Username can only include . _ - or @ as separators");
+                    },
+                    success: () => {
+                        throw new Error("Expected username validation to fail but it succeeded");
+                    },
+                });
+            });
+        });
+
+        describe("existing user (permissive) validation", () => {
+            it("should allow usernames with otherwise invalid characters for existing users", () => {
+                const result = Username.create("john/doe", true);
+
+                result.match({
+                    success: username => {
+                        expect(username.value).toBe("john/doe");
+                    },
+                    error: () => {
+                        throw new Error("Expected permissive username validation to succeed but it failed");
+                    },
+                });
+            });
+
+            it("should allow usernames with spaces for existing users", () => {
+                const result = Username.create("john doe", true);
+
+                expect(result.isSuccess()).toBe(true);
+            });
+
+            it("should still reject empty usernames for existing users", () => {
+                const result = Username.create("", true);
+
+                result.match({
+                    error: errors => {
+                        expect(errors).toContain("Please provide a username");
+                    },
+                    success: () => {
+                        throw new Error("Expected username validation to fail but it succeeded");
+                    },
+                });
+            });
+
+            it("should still enforce length bounds for existing users", () => {
+                const result = Username.create("a", true);
+
+                result.match({
+                    error: errors => {
+                        expect(errors).toContain("Username should be at least 2 characters long");
                     },
                     success: () => {
                         throw new Error("Expected username validation to fail but it succeeded");


### PR DESCRIPTION
### :pushpin: References                                                                                                                                                                                  
-   **Issue:** Closes [869cyeajx](https://app.clickup.com/t/869cyeajx)                         
                                                                                                                                                                                                            
### :memo: Implementation                                                                                                                                                                                
- [x] New broken usernames (with spaces, `/`, etc.) are rejected before reaching DHIS2, fixing the downstream Android SDK login failure.
                                                                                                                                                                                                            
### :video_camera: Screenshots/Screen capture

                                                                                                                

https://github.com/user-attachments/assets/539144cc-e358-409c-86cf-ae8ff5c6ebbc

                                                                                            
### :fire: Testing                                                                                                                                                                   
 


#869cyeajx