### PR TITLE
[fix]: Allow leading dot in usernames for existing users

### DIFF
--- a/src/domain/value-objects/Username.ts
+++ b/src/domain/value-objects/Username.ts
@@ -28,13 +28,13 @@ export class Username extends ValueObject<UsernameProps> {
             return Either.error([requiredError]);
         }
 
-        const startError = validateNotRegexp(value, /^[._@-]|[._@-]$/, "Username cannot start or end with a separator");
+        // DHIS2 accepts usernames starting with a dot, so existing users
+        // with such usernames must remain editable through this app.
+        const startEndRegex = isExistingUser ? /^[_@-]|[._@-]$/ : /^[._@-]|[._@-]$/;
+        const startError = validateNotRegexp(value, startEndRegex, "Username cannot start or end with a separator");
         const doubleError = validateNotRegexp(value, /([._@-]){2,}/, "Username cannot have two separators in a row");
-
-        // Existing users skip the character-set check: DHIS2 itself accepts
-        // characters outside this set, so legacy accounts already in the
-        // database may contain them — blocking here would make those users
-        // unreadable/uneditable through this app.
+        // Existing users also skip the character-set check: DHIS2 accepts
+        // characters outside this set, so legacy accounts may contain them.
         const charError = isExistingUser
             ? undefined
             : validateRegexp(value, /^[a-zA-Z0-9._@-]+$/, "Username can only include . _ - or @ as separators");

--- a/src/domain/value-objects/__tests__/Username.spec.ts
+++ b/src/domain/value-objects/__tests__/Username.spec.ts
@@ -368,6 +368,12 @@ describe("Username value object", () => {
                 expect(result.isSuccess()).toBe(true);
             });
 
+            it("should allow usernames starting with a dot for existing users", () => {
+                const result = Username.create(".johndoe", true);
+
+                expect(result.isSuccess()).toBe(true);
+            });
+
             it("should still reject empty usernames for existing users", () => {
                 const result = Username.create("", true);
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes [869cyeajx](https://app.clickup.com/t/869cyeajx)

### :memo: Implementation
DHIS2 accepts usernames starting with a dot (e.g. `.foo`), but the strict username validation re-enabled in #345 rejects any username starting with a separator. This would make existing DHIS2 accounts with leading-dot usernames uneditable through this app. 
**Follow-up to:** PR [#345 review comment](https://github.com/EyeSeeTea/user-extended-app/pull/345#pullrequestreview-4182747446)
                                                                                                                                                                                                                                                                       
  New users continue to be validated under the original strict rules.                                                                                                             
                                                                          
### :video_camera: Screenshots/Screen capture

### :fire: Testing

#869cyeajx