### PR TITLE
fix: handle null userCredentials when accessing username in import an…

### DIFF
--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -339,7 +339,7 @@ export class UserD2ApiRepository implements UserRepository {
                         user =>
                             new UserIdentifier({
                                 id: user.id,
-                                username: user.username ?? user.userCredentials.username,
+                                username: user.username || user.userCredentials?.username || "",
                                 name: user.name,
                             })
                     );
@@ -393,7 +393,7 @@ export class UserD2ApiRepository implements UserRepository {
                 user =>
                     new UserIdentifier({
                         id: user.id,
-                        username: user.username || user.userCredentials.username,
+                        username: user.username || user.userCredentials?.username ,
                         name: user.name,
                     })
             );

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -393,7 +393,7 @@ export class UserD2ApiRepository implements UserRepository {
                 user =>
                     new UserIdentifier({
                         id: user.id,
-                        username: user.username || user.userCredentials?.username ,
+                        username: user.username || user.userCredentials?.username || "",
                         name: user.name,
                     })
             );

--- a/src/legacy/models/userHelpers.js
+++ b/src/legacy/models/userHelpers.js
@@ -313,13 +313,13 @@ function getUserPayloadFromPlainAttributes(baseUser, userFields) {
 
 function getUsersToSave(users, existingUsersToUpdate) {
     const usersByUsername = _.keyBy(users, "username");
-    const existingUsernamesSet = new Set(existingUsersToUpdate.map(user => user.userCredentials.username));
+    const existingUsernamesSet = new Set(existingUsersToUpdate.map(user => user.username || user.userCredentials?.username));
     const usersToCreate = _(users)
         .filter(user => !existingUsernamesSet.has(user.username))
         .map(userAttributes => getUserPayloadFromPlainAttributes({}, userAttributes))
         .value();
     const usersToUpdate = existingUsersToUpdate.map(existingUser =>
-        getUserPayloadFromPlainAttributes(existingUser, usersByUsername[existingUser.userCredentials.username])
+        getUserPayloadFromPlainAttributes(existingUser, usersByUsername[existingUser.username || existingUser.userCredentials?.username])
     );
     const allUsers = usersToCreate.concat(usersToUpdate);
 
@@ -348,16 +348,16 @@ but that would require one request by each new user.
 
 async function getUserGroupsToSave(d2, api, usersToSave, existingUsersToUpdate) {
     const userGroupsByUsername = _(usersToSave)
-        .map(user => [user.userCredentials.username, (user.userGroups || []).map(ug => ug.id)])
+        .map(user => [user.username || user.userCredentials?.username, (user.userGroups || []).map(ug => ug.id)])
         .fromPairs()
         .value();
 
     const userGroupsInvolved = _(usersToSave).concat(existingUsersToUpdate).flatMap("userGroups").uniqBy("id").value();
     const usersByGroupId = _(usersToSave)
-        .uniqBy(user => user.userCredentials.username)
+        .uniqBy(user => user.username || user.userCredentials?.username)
         .flatMap(user => {
             const userGroupIds =
-                userGroupsByUsername[user.userCredentials.username] || user.userGroups.map(ug => ug.id);
+                userGroupsByUsername[user.username || user.userCredentials?.username] || user.userGroups.map(ug => ug.id);
             return userGroupIds.map(userGroupId => ({ user, userGroupId }));
         })
         .groupBy("userGroupId")
@@ -460,7 +460,7 @@ async function saveCopyInUsers(d2, users, copyUserGroups) {
             fields: ":owner,userCredentials,userGroups[id]",
             filter:
                 `${is242Plus ? "username" : "userCredentials.username"}:in:[` +
-                _(users).map("userCredentials.username").join(",") +
+                _(users).map(user => user.username || user.userCredentials?.username).join(",") +
                 "]",
         });
         return getUserGroupsToSaveAndPostMetadata(d2, api, users, existingUsersToUpdate);

--- a/src/legacy/models/userHelpers.js
+++ b/src/legacy/models/userHelpers.js
@@ -313,13 +313,18 @@ function getUserPayloadFromPlainAttributes(baseUser, userFields) {
 
 function getUsersToSave(users, existingUsersToUpdate) {
     const usersByUsername = _.keyBy(users, "username");
-    const existingUsernamesSet = new Set(existingUsersToUpdate.map(user => user.username || user.userCredentials?.username));
+    const existingUsernamesSet = new Set(
+        existingUsersToUpdate.map(user => user.username || user.userCredentials?.username)
+    );
     const usersToCreate = _(users)
         .filter(user => !existingUsernamesSet.has(user.username))
         .map(userAttributes => getUserPayloadFromPlainAttributes({}, userAttributes))
         .value();
     const usersToUpdate = existingUsersToUpdate.map(existingUser =>
-        getUserPayloadFromPlainAttributes(existingUser, usersByUsername[existingUser.username || existingUser.userCredentials?.username])
+        getUserPayloadFromPlainAttributes(
+            existingUser,
+            usersByUsername[existingUser.username || existingUser.userCredentials?.username]
+        )
     );
     const allUsers = usersToCreate.concat(usersToUpdate);
 
@@ -357,7 +362,8 @@ async function getUserGroupsToSave(d2, api, usersToSave, existingUsersToUpdate) 
         .uniqBy(user => user.username || user.userCredentials?.username)
         .flatMap(user => {
             const userGroupIds =
-                userGroupsByUsername[user.username || user.userCredentials?.username] || user.userGroups.map(ug => ug.id);
+                userGroupsByUsername[user.username || user.userCredentials?.username] ||
+                user.userGroups.map(ug => ug.id);
             return userGroupIds.map(userGroupId => ({ user, userGroupId }));
         })
         .groupBy("userGroupId")
@@ -460,7 +466,10 @@ async function saveCopyInUsers(d2, users, copyUserGroups) {
             fields: ":owner,userCredentials,userGroups[id]",
             filter:
                 `${is242Plus ? "username" : "userCredentials.username"}:in:[` +
-                _(users).map(user => user.username || user.userCredentials?.username).join(",") +
+                _(users)
+                    .map(user => user.username || user.userCredentials?.username)
+                    .compact()
+                    .join(",") +
                 "]",
         });
         return getUserGroupsToSaveAndPostMetadata(d2, api, users, existingUsersToUpdate);


### PR DESCRIPTION
### :pushpin: References

- **Issue:** Closes https://app.clickup.com/t/869dfnjjm

### :memo: Implementation

In some DHIS2 instances, users can exist without a `username` field (confirmed via `GET /api/users?filter=username:null`). When this happens, the code falls through to `user.userCredentials.username` — but in DHIS2 2.42+ `userCredentials` is no longer returned by the API, so this throws an error.

```typescript
  new UserIdentifier({  id: user.id, username: user.username ?? user.userCredentials.username, name: user.name,})
```

The fix applies optional chaining and a root-level `username` fallback consistently across all places that access `userCredentials.username`:

```typescript
new UserIdentifier({
    id: user.id,
    username: user.username || user.userCredentials?.username || "",
    name: user.name,})
```

> Note: the underlying cause is users in the instance with no username. Ideally those users should be fixed at the data level, but this change prevents the app from crashing when it encounters them.

### :fire: Testing

- List users: page loads without errors