### PR TITLE
refactor: decouple DHIS2 filter keys from domain and use cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ dist/
 .yarn/unplugged
 .yarn/build-state.yml
 .pnp.*
+.claude/settings.local.json

--- a/src/data/repositories/UserD2ApiRepository.ts
+++ b/src/data/repositories/UserD2ApiRepository.ts
@@ -6,7 +6,8 @@ import { Pager, PaginatedResponse } from "../../domain/entities/PaginatedRespons
 import { Id, NamedRef } from "../../domain/entities/Ref";
 import { Stats } from "../../domain/entities/Stats";
 import { User } from "../../domain/entities/User";
-import { ListFilters, ListOptions, UpdateStrategy, UserRepository } from "../../domain/repositories/UserRepository";
+import { ListOptions, UpdateStrategy, UserRepository } from "../../domain/repositories/UserRepository";
+import { translateUserFilters, D2ApiFilters } from "./UserFilterTranslator";
 import { LocaleCode } from "../../domain/entities/UserProps";
 import { UserIdentifier } from "../../domain/entities/UserIdentifier";
 import { Maybe } from "../../types/utils";
@@ -134,17 +135,16 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     public list(options: ListOptions): FutureData<PaginatedResponse<User>> {
-        return this.translateListFiltersForApi(options.filters).flatMap(({ is242Plus, filters }) => {
-            return this.listWithVersion({ ...options, filters }, is242Plus);
+        return this.getIs242Plus().flatMap(is242Plus => {
+            return this.listWithVersion(options, is242Plus);
         });
     }
 
     private listWithVersion(options: ListOptions, is242Plus: boolean): FutureData<PaginatedResponse<User>> {
-        const { page, pageSize, filters } = options;
+        const { page, pageSize } = options;
         const normalizedPage = page ?? 1;
         const normalizedPageSize = pageSize ?? 25;
         const idFilterValues = this.getIdInFilterValues(options);
-        const translatedFilters = filters;
 
         return this.getUsersIdsInChunks(options.hideUsers).flatMap(usersIdsToHide => {
             if (!idFilterValues || idFilterValues.length === 0) {
@@ -157,10 +157,10 @@ export class UserD2ApiRepository implements UserRepository {
                         },
                         page,
                         pageSize,
-                        ...this.createCommonListQueryParams({ ...options, filters: translatedFilters }, is242Plus),
+                        ...this.createCommonListQueryParams(options, is242Plus),
                     })
                 ).flatMap(({ objects, pager }) => {
-                    return this.recalculatePagination(options).map(newPager => {
+                    return this.recalculatePagination(options, is242Plus).map(newPager => {
                         const users = objects.map(user => this.toDomainUser(user as ApiUserWithAudit));
                         const excludeHiddenUsers = usersIdsToHide
                             ? users.filter(user => !usersIdsToHide.includes(user.id))
@@ -172,17 +172,14 @@ export class UserD2ApiRepository implements UserRepository {
 
             // If there is an ID filter, we need to chunk the requests to avoid URL length limits
             const sorting = options.sorting ?? { field: "firstName", order: "asc" };
-            const baseFilters = translatedFilters ?? {};
+            const baseFilters = options.filters ?? {};
 
             return chunkRequest(
                 idFilterValues,
                 idsChunk => {
                     const chunkOptions: ListOptions = {
                         ...options,
-                        filters: {
-                            ...baseFilters,
-                            id: ["in", idsChunk],
-                        },
+                        filters: { ...baseFilters, id: idsChunk },
                     };
 
                     return apiToFuture(
@@ -241,18 +238,8 @@ export class UserD2ApiRepository implements UserRepository {
         });
     }
 
-    private buildFilters(
-        filters: ListFilters | undefined,
-        override: { onlyActiveUsers: boolean },
-        is242Plus: boolean
-    ): Record<string, Record<string, string[]> | undefined> {
-        const otherFilters = _.mapValues(filters, items => (items ? { [items[0]]: items[1] } : undefined));
-        const disabledKey = is242Plus ? "disabled" : "userCredentials.disabled";
-
-        return {
-            ...otherFilters,
-            [disabledKey]: override.onlyActiveUsers ? { eq: ["false"] } : otherFilters[disabledKey],
-        };
+    private buildApiFilters(options: ListOptions, is242Plus: boolean): D2ApiFilters {
+        return translateUserFilters(options.filters, options.onlyActiveUsers, is242Plus);
     }
 
     private getUsersIdsInChunks(ids: Id[]): FutureData<Maybe<Id[]>> {
@@ -271,13 +258,13 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     public listAllIds(options: ListOptions): FutureData<string[]> {
-        return this.translateListFiltersForApi(options.filters).flatMap(({ is242Plus, filters }) => {
+        return this.getIs242Plus().flatMap(is242Plus => {
             return this.getUsersIdsInChunks(options.hideUsers).flatMap(usersIdsToExclude => {
                 return apiToFuture(
                     this.api.models.users.get({
                         fields: { id: true },
                         paging: false,
-                        ...this.createCommonListQueryParams({ ...options, filters }, is242Plus),
+                        ...this.createCommonListQueryParams(options, is242Plus),
                     })
                 ).map(({ objects }) => {
                     const usersIds = objects.map(user => user.id);
@@ -291,21 +278,19 @@ export class UserD2ApiRepository implements UserRepository {
         const {
             search,
             sorting = { field: "firstName", order: "asc" },
-            filters,
             canManage,
             rootJunction,
-            onlyActiveUsers,
             onlyUsersOrgUnits,
         } = options;
 
-        const otherFilters = this.buildFilters(filters, { onlyActiveUsers }, is242Plus);
-        const areFiltersEnabled = _(otherFilters).values().some();
+        const apiFilters = this.buildApiFilters(options, is242Plus);
+        const areFiltersEnabled = Object.values(apiFilters).some(v => v !== undefined && v !== null);
         const sortingField = sorting.field === "status" ? "disabled" : sorting.field;
 
         return {
             query: search !== "" ? search : undefined,
             canManage: canManage === "true" ? "true" : undefined,
-            filter: otherFilters,
+            filter: apiFilters,
             rootJunction: areFiltersEnabled ? rootJunction : undefined,
             userOrgUnits: onlyUsersOrgUnits ? "true" : undefined,
             includeChildren: onlyUsersOrgUnits ? "true" : undefined,
@@ -314,14 +299,13 @@ export class UserD2ApiRepository implements UserRepository {
     }
 
     public listAllUserIdentifiers(options: ListOptions): FutureData<UserIdentifier[]> {
-        return this.translateListFiltersForApi(options.filters).flatMap(({ is242Plus, filters }) => {
-            return this.listAllUserIdentifiersWithVersion({ ...options, filters }, is242Plus);
+        return this.getIs242Plus().flatMap(is242Plus => {
+            return this.listAllUserIdentifiersWithVersion(options, is242Plus);
         });
     }
 
     private listAllUserIdentifiersWithVersion(options: ListOptions, is242Plus: boolean): FutureData<UserIdentifier[]> {
         const idFilterValues = this.getIdInFilterValues(options);
-        const translatedFilters = options.filters;
 
         return this.getUsersIdsInChunks(options.hideUsers).flatMap(usersIdsToExclude => {
             if (!idFilterValues || idFilterValues.length === 0) {
@@ -329,7 +313,7 @@ export class UserD2ApiRepository implements UserRepository {
                     this.api.models.users.get({
                         fields: { id: true, name: true, username: true, userCredentials: { username: true } },
                         paging: false,
-                        ...this.createCommonListQueryParams({ ...options, filters: translatedFilters }, is242Plus),
+                        ...this.createCommonListQueryParams(options, is242Plus),
                     })
                 ).map(({ objects }) => {
                     const filteredObjects = usersIdsToExclude
@@ -346,17 +330,15 @@ export class UserD2ApiRepository implements UserRepository {
                 });
             }
 
-            return this.getUserIdentifiersInChunks({ ...options, filters: translatedFilters }, is242Plus, {
+            return this.getUserIdentifiersInChunks(options, is242Plus, {
                 userIds: idFilterValues,
                 usersIdsToExclude: usersIdsToExclude,
-            });
+            }); 
         });
     }
 
     private getIdInFilterValues(options: ListOptions): Maybe<Id[]> {
-        const filters = options.filters;
-        const idFilter = filters?.id;
-        const idFilterValues = idFilter?.[0] === "in" ? idFilter[1] : undefined;
+        const idFilterValues = options.filters?.id;
         return idFilterValues && idFilterValues.length > 0 ? idFilterValues : undefined;
     }
 
@@ -372,7 +354,7 @@ export class UserD2ApiRepository implements UserRepository {
         return chunkRequest(
             userIds,
             idsChunk => {
-                const chunkOptions: ListOptions = { ...options, filters: { ...baseFilters, id: ["in", idsChunk] } };
+                const chunkOptions: ListOptions = { ...options, filters: { ...baseFilters, id: idsChunk } };
 
                 return apiToFuture(
                     this.api.models.users.get({
@@ -488,12 +470,10 @@ export class UserD2ApiRepository implements UserRepository {
             pageSize,
             search,
             sorting = { field: "firstName", order: "asc" },
-            filters,
-            onlyActiveUsers,
         } = options;
 
-        // getFullUsers is only used internally for save() prefetch; keep legacy behavior (2.41 compatible)
-        const otherFilters = this.buildFilters(filters, { onlyActiveUsers }, false);
+        // getFullUsers is only used internally for save() prefetch; keep 2.41-compatible filter keys
+        const apiFilters = translateUserFilters(options.filters, options.onlyActiveUsers, false);
 
         const userData$ = apiToFuture(
             this.api.models.users.get({
@@ -507,7 +487,7 @@ export class UserD2ApiRepository implements UserRepository {
                 paging: false,
                 filter: {
                     identifiable: search ? { token: search } : undefined,
-                    ...otherFilters,
+                    ...apiFilters,
                 },
                 order: `${sorting.field}:${sorting.order}`,
                 v: +new Date().getTime(),
@@ -557,7 +537,7 @@ export class UserD2ApiRepository implements UserRepository {
 
         return this.getLogger().flatMap(logger => {
             return this.getFullUsers({
-                filters: { id: ["in", userIds] },
+                filters: { id: userIds },
                 onlyUsersOrgUnits: false,
                 onlyActiveUsers: false,
                 hideUsers: [],
@@ -1006,15 +986,18 @@ export class UserD2ApiRepository implements UserRepository {
         });
     }
 
-    private recalculatePagination(options: ListOptions): FutureData<Maybe<Pager>> {
+    private recalculatePagination(options: ListOptions, is242Plus: boolean): FutureData<Maybe<Pager>> {
         // There is a bug in v41 where the pager total and pageCount are incorrect when
         // filters are applied together with userOrgUnits=true. To work around this, we recalculate
         // the pagination based on the total number of users that match the filters.
         const { onlyUsersOrgUnits, filters = {} } = options;
-        const calculatePager =
-            onlyUsersOrgUnits && Object.entries(filters).filter(([_, v]) => v !== undefined && v !== null).length > 0;
+        const hasActiveFilters =
+            Object.entries(filters).filter(([_, v]) => v !== undefined && v !== null && (Array.isArray(v) ? v.length > 0 : true)).length > 0;
+        const calculatePager = onlyUsersOrgUnits && hasActiveFilters;
 
         if (!calculatePager) return Future.void();
+
+        if (is242Plus) return Future.void(); // Bug only on v41
 
         return Future.fromPromise(this.api.getVersion()).flatMap(version => {
             const majorVersion = getMajorVersion(version);
@@ -1024,11 +1007,10 @@ export class UserD2ApiRepository implements UserRepository {
 
             const optionsWithoutUserIds: ListOptions = {
                 ...options,
-                // @ts-expect-error
-                filters: { ...options.filters, id: ["in", undefined] },
+                filters: { ...options.filters, id: undefined },
             };
 
-            return this.listAllUserIdentifiers(optionsWithoutUserIds).map(userIds => {
+            return this.listAllUserIdentifiersWithVersion(optionsWithoutUserIds, false).map(userIds => {
                 return {
                     page: options.page ?? 1,
                     pageSize: options.pageSize ?? 25,
@@ -1044,34 +1026,6 @@ export class UserD2ApiRepository implements UserRepository {
         return Future.fromPromise(this.api.getVersion()).map(version => getMajorVersion(version) >= 42);
     }
 
-    private translateListFiltersForApi(
-        filters: ListFilters | undefined
-    ): FutureData<{ is242Plus: boolean; filters: ListFilters | undefined }> {
-        return this.getIs242Plus().map(is242Plus => {
-            if (!filters) return { is242Plus, filters };
-            if (!is242Plus) return { is242Plus, filters };
-
-            const prefix = "userCredentials.";
-            const rootWhitelist = new Set(["username", "disabled", "externalAuth", "lastLogin", "userRoles.id"]);
-
-            const translated = _(filters)
-                .toPairs()
-                .flatMap(([key, value]) => {
-                    if (!key.startsWith(prefix)) return [[key, value] as const];
-
-                    const candidate = key.slice(prefix.length);
-                    // In DHIS2 2.42, filters using userCredentials.* can fail. Only translate the keys
-                    // we know exist in the root user schema; drop the rest (e.g. twoFA).
-                    if (!rootWhitelist.has(candidate)) return [];
-
-                    return [[candidate, value] as const];
-                })
-                .fromPairs()
-                .value();
-
-            return { is242Plus, filters: translated };
-        });
-    }
 }
 
 const verifyPasswordResponseCodec = Codec.interface({

--- a/src/data/repositories/UserFilterTranslator.ts
+++ b/src/data/repositories/UserFilterTranslator.ts
@@ -1,0 +1,36 @@
+import { FilterBase } from "@eyeseetea/d2-api/api/common";
+import { UserListFilters } from "../../domain/repositories/UserRepository";
+
+export type D2ApiFilters = FilterBase;
+
+export function translateUserFilters(
+    filters: UserListFilters | undefined,
+    onlyActiveUsers: boolean,
+    is242Plus: boolean
+): D2ApiFilters {
+    const withVersionPrefix = (field: string) => (is242Plus ? field : `userCredentials.${field}`);
+    const equalityFilter = (v: boolean) => ({ eq: String(v) });
+    const arrayFilter = (ids: string[]) => ({ in: ids });
+
+    const disabledKey = withVersionPrefix("disabled");
+    const disabledEntry: D2ApiFilters = onlyActiveUsers
+        ? { [disabledKey]: equalityFilter(false) }
+        : filters?.disabled != null
+        ? { [disabledKey]: equalityFilter(filters.disabled) }
+        : {};
+
+    if (!filters) return disabledEntry;
+
+    return {
+        ...disabledEntry,
+        ...(!is242Plus && filters.twoFA != null ? { "userCredentials.twoFA": equalityFilter(filters.twoFA) } : {}),
+        ...(filters.externalAuth != null ? { [withVersionPrefix("externalAuth")]: equalityFilter(filters.externalAuth) } : {}),
+        ...(filters.userRoles?.length ? { [withVersionPrefix("userRoles.id")]: arrayFilter(filters.userRoles) } : {}),
+        ...(filters.userGroups?.length ? { "userGroups.id": arrayFilter(filters.userGroups) } : {}),
+        ...(filters.organisationUnits?.length ? { "organisationUnits.id": arrayFilter(filters.organisationUnits) } : {}),
+        ...(filters.dataViewOrganisationUnits?.length ? { "dataViewOrganisationUnits.id": arrayFilter(filters.dataViewOrganisationUnits) } : {}),
+        ...(filters.teiSearchOrganisationUnits?.length ? { "teiSearchOrganisationUnits.id": arrayFilter(filters.teiSearchOrganisationUnits) } : {}),
+        ...(filters.username?.length ? { [withVersionPrefix("username")]: arrayFilter(filters.username) } : {}),
+        ...(filters.id?.length ? { id: arrayFilter(filters.id) } : {}),
+    };
+}

--- a/src/data/repositories/__tests__/UserFilterTranslator.spec.ts
+++ b/src/data/repositories/__tests__/UserFilterTranslator.spec.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from "vitest";
+import { translateUserFilters } from "../UserFilterTranslator";
+import { UserListFilters } from "../../../domain/repositories/UserRepository";
+
+describe("onlyActiveUsers override", () => {
+    it("forces disabled=false on 2.41 (userCredentials prefix)", () => {
+        const result = translateUserFilters(undefined, true, false);
+
+        expect(result).toEqual({ "userCredentials.disabled": { eq: "false" } });
+    });
+
+    it("forces disabled=false on 2.42 (root key)", () => {
+        const result = translateUserFilters(undefined, true, true);
+
+        expect(result).toEqual({ disabled: { eq: "false" } });
+    });
+
+    it("onlyActiveUsers takes precedence over filters.disabled=true on 2.41", () => {
+        const result = translateUserFilters({ disabled: true }, true, false);
+
+        expect(result["userCredentials.disabled"]).toEqual({ eq: "false" });
+    });
+
+    it("onlyActiveUsers takes precedence over filters.disabled=true on 2.42", () => {
+        const result = translateUserFilters({ disabled: true }, true, true);
+
+        expect(result["disabled"]).toEqual({ eq: "false" });
+    });
+});
+
+describe("disabled filter (no onlyActiveUsers)", () => {
+    it("emits userCredentials.disabled on 2.41 when disabled=false", () => {
+        const result = translateUserFilters({ disabled: false }, false, false);
+
+        expect(result["userCredentials.disabled"]).toEqual({ eq: "false" });
+    });
+
+    it("emits root disabled on 2.42 when disabled=false", () => {
+        const result = translateUserFilters({ disabled: false }, false, true);
+
+        expect(result["disabled"]).toEqual({ eq: "false" });
+    });
+
+    it("emits disabled=true on 2.41", () => {
+        const result = translateUserFilters({ disabled: true }, false, false);
+
+        expect(result["userCredentials.disabled"]).toEqual({ eq: "true" });
+    });
+
+    it("omits disabled key when disabled is null", () => {
+        const result = translateUserFilters({ disabled: null }, false, false);
+
+        expect(result["userCredentials.disabled"]).toBeUndefined();
+        expect(result["disabled"]).toBeUndefined();
+    });
+
+    it("omits disabled key when disabled is undefined", () => {
+        const result = translateUserFilters({ disabled: undefined }, false, false);
+
+        expect(result["userCredentials.disabled"]).toBeUndefined();
+    });
+});
+
+describe("twoFA filter", () => {
+    it("emits userCredentials.twoFA on 2.41", () => {
+        const result = translateUserFilters({ twoFA: true }, false, false);
+
+        expect(result["userCredentials.twoFA"]).toEqual({ eq: "true" });
+    });
+
+    it("drops twoFA silently on 2.42", () => {
+        const result = translateUserFilters({ twoFA: true }, false, true);
+
+        expect(result["userCredentials.twoFA"]).toBeUndefined();
+    });
+
+    it("omits twoFA on 2.41 when null", () => {
+        const result = translateUserFilters({ twoFA: null }, false, false);
+
+        expect(result["userCredentials.twoFA"]).toBeUndefined();
+    });
+});
+
+describe("externalAuth filter", () => {
+    it("emits userCredentials.externalAuth on 2.41", () => {
+        const result = translateUserFilters({ externalAuth: true }, false, false);
+
+        expect(result["userCredentials.externalAuth"]).toEqual({ eq: "true" });
+    });
+
+    it("emits root externalAuth on 2.42", () => {
+        const result = translateUserFilters({ externalAuth: true }, false, true);
+
+        expect(result["externalAuth"]).toEqual({ eq: "true" });
+    });
+
+    it("omits externalAuth when null", () => {
+        const result = translateUserFilters({ externalAuth: null }, false, false);
+
+        expect(result["userCredentials.externalAuth"]).toBeUndefined();
+    });
+});
+
+describe("userRoles filter", () => {
+    it("emits userCredentials.userRoles.id on 2.41", () => {
+        const result = translateUserFilters({ userRoles: ["r1", "r2"] }, false, false);
+
+        expect(result["userCredentials.userRoles.id"]).toEqual({ in: ["r1", "r2"] });
+    });
+
+    it("emits root userRoles.id on 2.42", () => {
+        const result = translateUserFilters({ userRoles: ["r1", "r2"] }, false, true);
+
+        expect(result["userRoles.id"]).toEqual({ in: ["r1", "r2"] });
+    });
+
+    it("omits userRoles when empty array", () => {
+        const result = translateUserFilters({ userRoles: [] }, false, false);
+
+        expect(result["userCredentials.userRoles.id"]).toBeUndefined();
+    });
+});
+
+describe("org unit filters (same key on all versions)", () => {
+    it("emits organisationUnits.id", () => {
+        const result = translateUserFilters({ organisationUnits: ["ou1"] }, false, false);
+
+        expect(result["organisationUnits.id"]).toEqual({ in: ["ou1"] });
+    });
+
+    it("emits organisationUnits.id on 2.42", () => {
+        const result = translateUserFilters({ organisationUnits: ["ou1"] }, false, true);
+
+        expect(result["organisationUnits.id"]).toEqual({ in: ["ou1"] });
+    });
+
+    it("emits dataViewOrganisationUnits.id", () => {
+        const result = translateUserFilters({ dataViewOrganisationUnits: ["dv1"] }, false, false);
+
+        expect(result["dataViewOrganisationUnits.id"]).toEqual({ in: ["dv1"] });
+    });
+
+    it("emits teiSearchOrganisationUnits.id", () => {
+        const result = translateUserFilters({ teiSearchOrganisationUnits: ["s1"] }, false, false);
+
+        expect(result["teiSearchOrganisationUnits.id"]).toEqual({ in: ["s1"] });
+    });
+
+    it("omits org units when empty", () => {
+        const result = translateUserFilters({ organisationUnits: [] }, false, false);
+
+        expect(result["organisationUnits.id"]).toBeUndefined();
+    });
+});
+
+describe("username filter", () => {
+    it("emits userCredentials.username on 2.41", () => {
+        const result = translateUserFilters({ username: ["admin", "bob"] }, false, false);
+
+        expect(result["userCredentials.username"]).toEqual({ in: ["admin", "bob"] });
+    });
+
+    it("emits root username on 2.42", () => {
+        const result = translateUserFilters({ username: ["admin", "bob"] }, false, true);
+
+        expect(result["username"]).toEqual({ in: ["admin", "bob"] });
+    });
+});
+
+describe("id filter", () => {
+    it("emits id on any version", () => {
+        const ids = ["abc123", "def456"];
+
+        expect(translateUserFilters({ id: ids }, false, false)["id"]).toEqual({ in: ids });
+        expect(translateUserFilters({ id: ids }, false, true)["id"]).toEqual({ in: ids });
+    });
+
+    it("omits id when empty", () => {
+        const result = translateUserFilters({ id: [] }, false, false);
+
+        expect(result["id"]).toBeUndefined();
+    });
+});
+
+describe("undefined filters", () => {
+    it("returns empty object when filters undefined and onlyActiveUsers false", () => {
+        expect(translateUserFilters(undefined, false, false)).toEqual({});
+        expect(translateUserFilters(undefined, false, true)).toEqual({});
+    });
+});
+
+describe("combined scenario (2.41, onlyActive + roles + groups)", () => {
+    it("produces correct combined filter", () => {
+        const filters: UserListFilters = {
+            userRoles: ["r1"],
+            userGroups: ["g1"],
+        };
+        const result = translateUserFilters(filters, true, false);
+
+        expect(result["userCredentials.disabled"]).toEqual({ eq: "false" });
+        expect(result["userCredentials.userRoles.id"]).toEqual({ in: ["r1"] });
+        expect(result["userGroups.id"]).toEqual({ in: ["g1"] });
+    });
+});
+
+describe("combined scenario (2.42, disabled filter + externalAuth)", () => {
+    it("produces correct root-level keys", () => {
+        const filters: UserListFilters = {
+            disabled: true,
+            externalAuth: false,
+        };
+        const result = translateUserFilters(filters, false, true);
+
+        expect(result["disabled"]).toEqual({ eq: "true" });
+        expect(result["externalAuth"]).toEqual({ eq: "false" });
+        expect(result["userCredentials.disabled"]).toBeUndefined();
+        expect(result["userCredentials.externalAuth"]).toBeUndefined();
+    });
+});

--- a/src/domain/repositories/UserRepository.ts
+++ b/src/domain/repositories/UserRepository.ts
@@ -24,12 +24,25 @@ export interface UserRepository {
     getInMyOrgUnit(): FutureData<UserIdentifier[]>;
 }
 
+export interface UserListFilters {
+    disabled?: boolean | null;
+    twoFA?: boolean | null;
+    externalAuth?: boolean | null;
+    userRoles?: string[];
+    userGroups?: string[];
+    organisationUnits?: string[];
+    dataViewOrganisationUnits?: string[];
+    teiSearchOrganisationUnits?: string[];
+    username?: string[];
+    id?: string[];
+}
+
 export interface ListOptions {
     page?: number;
     pageSize?: number;
     search?: string;
     sorting?: { field: string; order: "asc" | "desc" };
-    filters?: ListFilters;
+    filters?: UserListFilters;
     canManage?: string;
     rootJunction?: "AND" | "OR";
     onlyUsersOrgUnits: boolean;
@@ -37,8 +50,6 @@ export interface ListOptions {
     hideUsers: Id[];
 }
 
-export type ListFilterType = "in" | "eq" | "gt";
-export type ListFilters = Record<string, [ListFilterType, string[]]>;
 export type UpdateStrategy = "replace" | "merge";
 
 export type AccessElements = {

--- a/src/domain/usecases/ImportUsersUseCase.ts
+++ b/src/domain/usecases/ImportUsersUseCase.ts
@@ -53,7 +53,7 @@ export class ImportUsersUseCase implements UseCase {
                                 onlyActiveUsers: false,
                                 onlyUsersOrgUnits: false,
                                 hideUsers: [],
-                                filters: { "userCredentials.username": ["in", usernameList] },
+                                filters: { username: usernameList },
                             })
                             .flatMap(usersFromDB => {
                                 const mergedUsers = this.mergeUsers(userChunk, usersFromDB, currentUser);

--- a/src/domain/usecases/ListUsersUseCase.ts
+++ b/src/domain/usecases/ListUsersUseCase.ts
@@ -6,7 +6,7 @@ import { Pager } from "../entities/PaginatedResponse";
 import { User } from "../entities/User";
 import { isSuperAdmin } from "../entities/UserProps";
 import { AppSettingsRepository } from "../repositories/AppSettingsRepository";
-import { UserRepository, ListOptions, ListFilterType } from "../repositories/UserRepository";
+import { UserRepository, ListOptions, UserListFilters } from "../repositories/UserRepository";
 import { getAppSettings } from "./common/settings";
 
 export class ListUsersUseCase implements UseCase {
@@ -32,18 +32,17 @@ export class ListUsersUseCase implements UseCase {
         options: ListOptions,
         appSettings: AppSettings
     ): FutureData<{ pager: Pager; objects: User[] }> {
-        const disabledKey = "userCredentials.disabled";
+        // Separate the disabled filter from the rest so we can combine each
+        // non-disabled filter with disabled in individual OR-junction requests.
+        const { disabled, ...restFilters } = options.filters ?? {};
 
-        const otherFilters = _(options.filters)
-            .map((items, key) => {
-                if (key === disabledKey) return undefined;
-                if (!items) return undefined;
-                return { fieldName: key, values: items };
-            })
-            .compact()
-            .value();
+        const activeFilterEntries = Object.entries(restFilters).filter(([_, value]) => {
+            if (value === undefined || value === null) return false;
+            if (Array.isArray(value)) return value.length > 0;
+            return true;
+        });
 
-        if (otherFilters.length === 0) {
+        if (activeFilterEntries.length === 0) {
             return this.userRepository.list({
                 ...options,
                 onlyActiveUsers: false,
@@ -51,18 +50,13 @@ export class ListUsersUseCase implements UseCase {
             });
         }
 
-        const disabledFilter = options.filters ? options.filters["userCredentials.disabled"] : undefined;
-
-        const baseFilters: Record<string, [ListFilterType, string[]]> = {
-            ...(disabledFilter ? { "userCredentials.disabled": disabledFilter } : {}),
+        const baseFilters: UserListFilters = {
+            ...(disabled !== null && disabled !== undefined ? { disabled } : {}),
         };
 
-        const $requests = otherFilters.map(filter => {
+        const $requests = activeFilterEntries.map(([fieldName, fieldValue]) => {
             return this.userRepository.listAll({
-                filters: {
-                    ...baseFilters,
-                    [filter.fieldName]: filter.values,
-                },
+                filters: { ...baseFilters, [fieldName]: fieldValue },
                 hideUsers: appSettings.hide.users,
                 onlyActiveUsers: options.onlyActiveUsers,
                 onlyUsersOrgUnits: options.onlyUsersOrgUnits,

--- a/src/legacy/List/Filters.component.js
+++ b/src/legacy/List/Filters.component.js
@@ -185,28 +185,22 @@ export default class Filters extends React.Component {
             rootJunction,
         } = this.state;
 
-        const inFilter = field => (_(field).isEmpty() ? null : ["in", field]);
-
-        const is242Plus = this.getIs242Plus();
+        // Helper: convert an array to an id list, or undefined when empty.
+        const inFilter = field => (_(field).isEmpty() ? undefined : field);
 
         return {
             ...(showOnlyManagedUsers ? { canManage: "true" } : {}),
             ...(searchString ? { query: searchString } : {}),
             ...(rootJunction ? { rootJunction } : {}),
             filters: {
-                [is242Plus ? "disabled" : "userCredentials.disabled"]:
-                    userDisabled !== null ? ["eq", userDisabled] : undefined,
-                // DHIS2 2.42 removed twoFA from userCredentials responses for security
-                ...(is242Plus
-                    ? {}
-                    : { "userCredentials.twoFA": twoFactorEnabled !== null ? ["eq", twoFactorEnabled] : undefined }),
-                [is242Plus ? "externalAuth" : "userCredentials.externalAuth"]:
-                    externalAuth !== null ? ["eq", externalAuth] : undefined,
-                [is242Plus ? "userRoles.id" : "userCredentials.userRoles.id"]: inFilter(userRoles),
-                "userGroups.id": inFilter(userGroups),
-                "organisationUnits.id": inFilter(orgUnits.map(ou => ou.id)),
-                "dataViewOrganisationUnits.id": inFilter(orgUnitsOutput.map(ou => ou.id)),
-                "teiSearchOrganisationUnits.id": inFilter(searchOrgUnits.map(ou => ou.id)),
+                disabled: userDisabled !== null ? userDisabled : undefined,
+                twoFA: twoFactorEnabled !== null ? twoFactorEnabled : undefined,
+                externalAuth: externalAuth !== null ? externalAuth : undefined,
+                userRoles: inFilter(userRoles),
+                userGroups: inFilter(userGroups),
+                organisationUnits: inFilter(orgUnits.map(ou => ou.id)),
+                dataViewOrganisationUnits: inFilter(orgUnitsOutput.map(ou => ou.id)),
+                teiSearchOrganisationUnits: inFilter(searchOrgUnits.map(ou => ou.id)),
             },
         };
     };

--- a/src/legacy/List/List.component.js
+++ b/src/legacy/List/List.component.js
@@ -300,18 +300,19 @@ class ListHybrid extends React.Component {
 function getFilters(filters, props, prevProps) {
     const areFiltersOverrided = props.onlyActiveUsers;
     const onlyActiveUsersChanged = prevProps?.onlyActiveUsers !== props.onlyActiveUsers;
-    const userCredentialsDisabled = onlyActiveUsersChanged
+    
+    const disabledFilter = onlyActiveUsersChanged
         ? props.onlyActiveUsers
-            ? ["eq", false]
+            ? false // show only active (disabled=false)
             : undefined
-        : filters?.filters?.["userCredentials.disabled"];
+        : filters?.filters?.disabled;
 
     return {
         ...filters,
         rootJunction: areFiltersOverrided ? "AND" : filters.rootJunction ?? "OR",
         filters: {
             ...filters.filters,
-            "userCredentials.disabled": userCredentialsDisabled,
+            disabled: disabledFilter,
         },
     };
 }

--- a/src/webapp/components/user-list-table/UserListTable.tsx
+++ b/src/webapp/components/user-list-table/UserListTable.tsx
@@ -18,7 +18,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Id, NamedRef } from "../../../domain/entities/Ref";
 import { User } from "../../../domain/entities/User";
-import { ListFilters, UpdateStrategy, AccessElements, ListOptions } from "../../../domain/repositories/UserRepository";
+import { UserListFilters, UpdateStrategy, AccessElements, ListOptions } from "../../../domain/repositories/UserRepository";
 import { isSuperAdmin } from "../../../domain/entities/UserProps";
 import { SaveUserOrgUnitOptions } from "../../../domain/usecases/SaveUserOrgUnitUseCase";
 import i18n from "../../../utils/i18n";
@@ -461,25 +461,25 @@ export const UserListTable: React.FC<UserListTableProps> = ({
             onChangeSearch(search);
 
             // SEE: src/legacy/models/userList.js LINE 29+
-            if (canManage === "true") {
-                const userIdList = await compositionRoot.users
-                    .listAllIdentifiers({
-                        search,
-                        sorting,
-                        filters,
-                        canManage,
-                        rootJunction,
-                        onlyUsersOrgUnits,
-                        onlyActiveUsers: onlyActiveUsers,
-                        hideUsers: appSettings.hide.users,
-                    })
-                    .toPromise()
-                    .then(userIdentifiers => userIdentifiers.map(user => user.id));
-
-                if (userIdList) {
-                    filters["id"] = ["in", userIdList];
-                }
-            }
+            const resolvedFilters: UserListFilters =
+                canManage === "true"
+                    ? {
+                          ...filters,
+                          id: await compositionRoot.users
+                              .listAllIdentifiers({
+                                  search,
+                                  sorting,
+                                  filters,
+                                  canManage,
+                                  rootJunction,
+                                  onlyUsersOrgUnits,
+                                  onlyActiveUsers: onlyActiveUsers,
+                                  hideUsers: appSettings.hide.users,
+                              })
+                              .toPromise()
+                              .then(userIdentifiers => userIdentifiers.map(user => user.id)),
+                      }
+                    : filters;
 
             return compositionRoot.users
                 .list({
@@ -487,7 +487,7 @@ export const UserListTable: React.FC<UserListTableProps> = ({
                     page,
                     pageSize,
                     sorting,
-                    filters,
+                    filters: resolvedFilters,
                     canManage,
                     rootJunction,
                     onlyUsersOrgUnits,
@@ -706,7 +706,7 @@ export type UserActionName =
 
 export interface UserListTableProps extends Pick<ObjectsTableProps<User>, "loading"> {
     openSettings: (settings: Settings) => void;
-    filters: ListFilters;
+    filters: UserListFilters;
     canManage: string;
     rootJunction: "AND" | "OR";
     onChangeVisibleColumns: (columns: string[]) => void;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** https://app.clickup.com/t/869ctkw05

### :memo: Implementation

PR #342 added DHIS2 v2.42 compatibility by switching API filter keys (e.g. `userCredentials.disabled` → `disabled`) inside the repository, but the version-awareness leaked into all layers: domain use cases used raw DHIS2 strings as filter keys, the legacy presentation layer called `getIs242Plus()` to build filter objects, and `UserListTable` mutated the `filters` prop.

This refactor confines the translation to the data layer:

- **`UserListFilters`** (domain): new typed interface with semantic fields (`disabled: boolean`, `username: string[]`, …) — no DHIS2 operator strings.
- **`UserFilterTranslator`** (data): pure function that maps `UserListFilters → D2ApiFilters` applying the correct key prefix per DHIS2 version; called only from the repository.
- **`UserD2ApiRepository`**: drops the old `translateListFiltersForApi` / `buildFilters` pair; delegates to `UserFilterTranslator`.
- **`ListUsersUseCase` / `ImportUsersUseCase`**: now use domain field names (`disabled`, `username`).
- **`Filters.component.js`**: `getFilterOptions()` returns plain domain fields; `getIs242Plus()` is kept only to hide the 2FA filter on v2.42+ UI.
- **`List.component.js`**: `getFilters()` uses `disabled` instead of `userCredentials.disabled`.
- **`UserListTable.tsx`**: filter `id` assignment is now immutable (spread instead of mutation).
- **30 unit tests** covering all field/version combinations, `onlyActiveUsers` override, null/empty edge cases.

### :video_camera: Screenshots/Screen capture

N/A — internal refactor, no UI changes.

### :fire: Testing

- All 201 existing tests pass (`yarn test`).
- TypeScript compiles with no errors (`tsc --noEmit`).
- Smoke test: filter by role, group, org unit, disabled status on DHIS2 v2.41 and v2.42 instances.