### PR TITLE
Fix/allow wrong usernames in read mode

### DIFF
--- a/src/domain/entities/__tests__/Users.spec.ts
+++ b/src/domain/entities/__tests__/Users.spec.ts
@@ -78,7 +78,7 @@ describe("User Entity", () => {
         dbLocale: "en",
     };
 
-    describe("createNewUser factory method", () => {
+    describe("createNew factory method", () => {
         describe("successful creation", () => {
             it("should create a new user with valid properties", () => {
                 const user = User.createNew(validUserProps).getOrThrow();
@@ -457,7 +457,7 @@ describe("User Entity", () => {
         });
     });
 
-    describe("createUser factory method", () => {
+    describe("createExisted factory method", () => {
         describe("successful creation with skipSourceErrors", () => {
             it("should create a user with valid properties and skip source errors", () => {
                 const propsWithMissingFields = {
@@ -481,6 +481,24 @@ describe("User Entity", () => {
 
                 expect(user).toBeInstanceOf(User);
                 expect(user.username).toBe("johndoe");
+            });
+
+            it("should create a user for existing user without username", () => {
+                const propsWithoutUsername = { ...validUserProps, username: "" };
+
+                const user = User.createExisted(propsWithoutUsername).getOrThrow();
+
+                expect(user).toBeInstanceOf(User);
+                expect(user.username).toBe("");
+            });
+
+            it("should create a user for existing user with invalid username", () => {
+                const propsWithInvalidUsername = { ...validUserProps, username: "_invalid..username" };
+
+                const user = User.createExisted(propsWithInvalidUsername).getOrThrow();
+
+                expect(user).toBeInstanceOf(User);
+                expect(user.username).toBe("_invalid..username");
             });
 
             it("should allow missing organisation units when skipSourceErrors is true", () => {
@@ -539,22 +557,6 @@ describe("User Entity", () => {
                     error: errors => {
                         expect(errors).toHaveLength(1);
                         expect(errors[0]?.errors).toContain("First name is required");
-                    },
-                    success: () => {
-                        throw new Error("Expected validation to fail but it succeeded");
-                    },
-                });
-            });
-
-            it("should still validate username format", () => {
-                const propsWithInvalidUsername = { ...validUserProps, username: "invalid..username" };
-
-                const userResult = User.createExisted(propsWithInvalidUsername);
-
-                userResult.match({
-                    error: errors => {
-                        expect(errors).toHaveLength(1);
-                        expect(errors[0]?.errors).toContain("Username cannot have two separators in a row");
                     },
                     success: () => {
                         throw new Error("Expected validation to fail but it succeeded");

--- a/src/domain/value-objects/Username.ts
+++ b/src/domain/value-objects/Username.ts
@@ -22,6 +22,11 @@ export class Username extends ValueObject<UsernameProps> {
     }
 
     public static create(value: string, isExistingUser = false): Either<string[], Username> {
+        // For existing users, wrong username is allowed
+        if (isExistingUser) {
+            return Either.success(new Username({ value }));
+        }
+
         const requiredError = validateRequired(value, "Please provide a username");
 
         if (requiredError) {

--- a/src/domain/value-objects/Username.ts
+++ b/src/domain/value-objects/Username.ts
@@ -33,16 +33,15 @@ export class Username extends ValueObject<UsernameProps> {
             return Either.error([requiredError]);
         }
 
-        // DHIS2 accepts usernames starting with a dot, so existing users
-        // with such usernames must remain editable through this app.
-        const startEndRegex = isExistingUser ? /^[_@-]|[._@-]$/ : /^[._@-]|[._@-]$/;
+        const startEndRegex = /^[._@-]|[._@-]$/;
         const startError = validateNotRegexp(value, startEndRegex, "Username cannot start or end with a separator");
         const doubleError = validateNotRegexp(value, /([._@-]){2,}/, "Username cannot have two separators in a row");
-        // Existing users also skip the character-set check: DHIS2 accepts
-        // characters outside this set, so legacy accounts may contain them.
-        const charError = isExistingUser
-            ? undefined
-            : validateRegexp(value, /^[a-zA-Z0-9._@-]+$/, "Username can only include . _ - or @ as separators");
+
+        const charError = validateRegexp(
+            value,
+            /^[a-zA-Z0-9._@-]+$/,
+            "Username can only include . _ - or @ as separators"
+        );
 
         const minLengthError = validateLengthMin(value, 2, "Username should be at least 2 characters long");
         const maxLengthError = validateLengthMax(value, 255, "Username may not exceed 255 characters");

--- a/src/domain/value-objects/__tests__/Username.spec.ts
+++ b/src/domain/value-objects/__tests__/Username.spec.ts
@@ -374,30 +374,16 @@ describe("Username value object", () => {
                 expect(result.isSuccess()).toBe(true);
             });
 
-            it("should still reject empty usernames for existing users", () => {
+            it("should allow empty usernames for existing users", () => {
                 const result = Username.create("", true);
 
-                result.match({
-                    error: errors => {
-                        expect(errors).toContain("Please provide a username");
-                    },
-                    success: () => {
-                        throw new Error("Expected username validation to fail but it succeeded");
-                    },
-                });
+                expect(result.isSuccess()).toBe(true);
             });
 
-            it("should still enforce length bounds for existing users", () => {
+            it("should allow empty length bounds for existing users", () => {
                 const result = Username.create("a", true);
 
-                result.match({
-                    error: errors => {
-                        expect(errors).toContain("Username should be at least 2 characters long");
-                    },
-                    success: () => {
-                        throw new Error("Expected username validation to fail but it succeeded");
-                    },
-                });
+                expect(result.isSuccess()).toBe(true);
             });
         });
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/869dpf5jh

### :memo: Implementation

- [x] avoid all validations and allow wrong names in read mode

### :video_camera: Screenshots/Screen capture
<img width="1918" height="931" alt="Screenshot 2026-06-15 at 10 26 39" src="https://github.com/user-attachments/assets/251d21c4-f7e3-40ac-8ef2-85ae8040425b" />

### :fire: Testing
